### PR TITLE
Fix bug with class command

### DIFF
--- a/src/main/java/seedu/taassist/logic/parser/ClassCommandParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/ClassCommandParser.java
@@ -3,6 +3,7 @@ package seedu.taassist.logic.parser;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.taassist.logic.commands.ClassCommand;
+import static seedu.taassist.logic.parser.ParserUtil.parseModuleClass;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.moduleclass.ModuleClass;
 
@@ -18,6 +19,7 @@ public class ClassCommandParser implements Parser<ClassCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClassCommand.MESSAGE_USAGE));
         }
-        return new ClassCommand(new ModuleClass(trimmedArgs));
+        ModuleClass moduleClass = parseModuleClass(trimmedArgs);
+        return new ClassCommand(moduleClass);
     }
 }

--- a/src/main/java/seedu/taassist/logic/parser/ClassCommandParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/ClassCommandParser.java
@@ -1,9 +1,9 @@
 package seedu.taassist.logic.parser;
 
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taassist.logic.parser.ParserUtil.parseModuleClass;
 
 import seedu.taassist.logic.commands.ClassCommand;
-import static seedu.taassist.logic.parser.ParserUtil.parseModuleClass;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.moduleclass.ModuleClass;
 


### PR DESCRIPTION
Fixed the class command by using the `parseModuleClass` in `ParserUtil` to return the `ModuleClass` instead of calling the `ModuleClass` constructor