### PR TITLE
Make student cards collapsible

### DIFF
--- a/src/main/java/seedu/taassist/ui/StudentCard.java
+++ b/src/main/java/seedu/taassist/ui/StudentCard.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.TitledPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -25,13 +26,12 @@ public class StudentCard extends UiPart<Region> {
      */
 
     public final Student student;
+    public final int index;
 
     @FXML
     private HBox cardPane;
     @FXML
-    private Label name;
-    @FXML
-    private Label id;
+    private TitledPane titledPane;
     @FXML
     private Label phone;
     @FXML
@@ -44,11 +44,11 @@ public class StudentCard extends UiPart<Region> {
     /**
      * Creates a {@code StudentCode} with the given {@code Student} and index to display.
      */
-    public StudentCard(Student student, int displayedIndex) {
+    public StudentCard(Student student, int index) {
         super(FXML);
         this.student = student;
-        id.setText(displayedIndex + ". ");
-        name.setText(student.getName().fullName);
+        this.index = index;
+        titledPane.setText(index + ". " + student.getName().fullName);
         phone.setText(student.getPhone().value);
         address.setText(student.getAddress().value);
         email.setText(student.getEmail().value);
@@ -71,7 +71,6 @@ public class StudentCard extends UiPart<Region> {
 
         // state check
         StudentCard card = (StudentCard) other;
-        return id.getText().equals(card.id.getText())
-                && student.equals(card.student);
+        return index == card.index && student.equals(card.student);
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -99,11 +99,11 @@
     -fx-padding: 0 0 0 0;
 }
 
-.list-cell:filled:even {
+.list-cell:filled:even .content {
     -fx-background-color: #3c3e3f;
 }
 
-.list-cell:filled:odd {
+.list-cell:filled:odd .content {
     -fx-background-color: #515658;
 }
 
@@ -118,6 +118,18 @@
 
 .list-cell .label {
     -fx-text-fill: white;
+}
+
+.list-cell .title .text {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 16px;
+    -fx-text-fill: #010504;
+}
+
+.list-cell .title > .arrow-button .arrow {
+    -fx-background-color: -fx-mark-highlight-color, -fx-mark-color;
+    -fx-background-insets: 0 0 0 0, 0;
+    -fx-padding: 0 0 0 0;
 }
 
 .cell_big_label {

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -2,39 +2,23 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane HBox.hgrow="ALWAYS">
-    <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-    </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
-      <padding>
-        <Insets bottom="5" left="15" right="5" top="5" />
-      </padding>
-      <HBox alignment="CENTER_LEFT" spacing="5">
-        <Label fx:id="id" styleClass="cell_big_label">
-          <minWidth>
-            <!-- Ensures that the label text is never truncated -->
-            <Region fx:constant="USE_PREF_SIZE" />
-          </minWidth>
-        </Label>
-        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
-      </HBox>
-      <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-    </VBox>
-      <rowConstraints>
-         <RowConstraints />
-      </rowConstraints>
-  </GridPane>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml/1">
+   <TitledPane id="titledPane" fx:id="titledPane" text="\\$name" HBox.hgrow="ALWAYS">
+      <content>
+       <VBox alignment="CENTER_LEFT" minHeight="105">
+         <padding>
+           <Insets bottom="5" left="15" right="5" top="5" />
+         </padding>
+         <FlowPane fx:id="tags" />
+         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+         <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+       </VBox>
+      </content>
+   </TitledPane>
 </HBox>


### PR DESCRIPTION
_Work in Progress_. Resolves #77. 

Current looks: 

![Screenshot_20221007_184136](https://user-images.githubusercontent.com/22095441/194536186-2c9bd6a6-dde8-4582-af49-1b3877614abe.png)

Todo: 
- [ ] Have an appropriate color / gradient for the titles.
- [ ] Have (or not have) different colors when focused. 
- [ ] Show an arrow head to the right (default is left, which is currently hidden by CSS). 

Give your thoughts in the comments. Suggest appropriate colors. 