### PR TITLE
Rename missing references to Tag

### DIFF
--- a/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
@@ -49,7 +49,7 @@ public class SampleDataUtil {
     }
 
     /**
-     * Returns a tag set containing the list of strings given.
+     * Returns a {@code ModuleClass} set containing the list of strings given.
      */
     public static Set<ModuleClass> getModuleClassSet(String... strings) {
         return Arrays.stream(strings)

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
@@ -34,9 +34,9 @@ class JsonAdaptedModuleClass {
     }
 
     /**
-     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     * Converts this Json-friendly adapted module class object into the model's {@code ModuleClass} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted module class.
      */
     public ModuleClass toModelType() throws IllegalValueException {
         if (!ModuleClass.isValidModuleClassName(className)) {

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
@@ -36,7 +36,7 @@ class JsonAdaptedStudent {
     @JsonCreator
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tagged") List<JsonAdaptedModuleClass> moduleClasses) {
+            @JsonProperty("classes") List<JsonAdaptedModuleClass> moduleClasses) {
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -337,12 +337,12 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#classes {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#tags .label {
+#classes .label {
     -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -8,13 +8,6 @@
     -fx-background: #383838;
 }
 
-.tag-selector {
-    -fx-border-width: 1;
-    -fx-border-color: white;
-    -fx-border-radius: 3;
-    -fx-background-radius: 3;
-}
-
 .tooltip-text {
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -4,7 +4,6 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
-
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
   <Label fx:id="focusLabel" styleClass="label-bright"  StackPane.alignment="TOP_RIGHT">

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -9,7 +9,6 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
-
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>

--- a/src/test/data/JsonSerializableTaAssistTest/duplicateStudentTaAssist.json
+++ b/src/test/data/JsonSerializableTaAssistTest/duplicateStudentTaAssist.json
@@ -4,7 +4,7 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
-    "tagged": [ "friends" ]
+    "classes": [ "friends" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",

--- a/src/test/data/JsonSerializableTaAssistTest/typicalStudentsTaAssist.json
+++ b/src/test/data/JsonSerializableTaAssistTest/typicalStudentsTaAssist.json
@@ -5,43 +5,43 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tagged" : [ "friends" ]
+    "classes" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "tagged" : [ "owesMoney", "friends" ]
+    "classes" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tagged" : [ ]
+    "classes" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tagged" : [ "friends" ]
+    "classes" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tagged" : [ ]
+    "classes" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tagged" : [ ]
+    "classes" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tagged" : [ ]
+    "classes" : [ ]
   } ],
   "moduleClasses" : []
 }

--- a/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
@@ -34,8 +34,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_CLASS_HUSBAND = "husband";
+    public static final String VALID_CLASS_FRIEND = "friend";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -45,8 +45,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_MODULE_CLASS + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_MODULE_CLASS + VALID_TAG_HUSBAND;
+    public static final String CLASS_DESC_FRIEND = " " + PREFIX_MODULE_CLASS + VALID_CLASS_FRIEND;
+    public static final String CLASS_DESC_HUSBAND = " " + PREFIX_MODULE_CLASS + VALID_CLASS_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -62,10 +62,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withModuleClasses(VALID_TAG_FRIEND).build();
+                .withModuleClasses(VALID_CLASS_FRIEND).build();
         DESC_BOB = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withModuleClasses(VALID_CLASS_HUSBAND, VALID_CLASS_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
@@ -51,7 +51,7 @@ public class CommandTestUtil {
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
-    public static final String INVALID_TAG_DESC = " " + PREFIX_MODULE_CLASS + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_CLASS_DESC = " " + PREFIX_MODULE_CLASS + "hubby*"; // '*' not allowed in classes
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/taassist/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/EditCommandTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taassist.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.taassist.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.taassist.logic.commands.CommandTestUtil.showStudentAtIndex;
@@ -55,10 +55,10 @@ public class EditCommandTest {
 
         StudentBuilder studentInList = new StudentBuilder(lastStudent);
         Student editedStudent = studentInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND).build();
+                .withModuleClasses(VALID_CLASS_HUSBAND).build();
 
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withModuleClasses(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withModuleClasses(VALID_CLASS_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastStudent, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent);

--- a/src/test/java/seedu/taassist/logic/commands/EditStudentDescriptorTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/EditStudentDescriptorTest.java
@@ -51,7 +51,7 @@ public class EditStudentDescriptorTest {
         editedAmy = new EditStudentDescriptorBuilder(DESC_AMY).withAddress(VALID_ADDRESS_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
-        // different tags -> returns false
+        // different classes -> returns false
         editedAmy = new EditStudentDescriptorBuilder(DESC_AMY).withModuleClasses(VALID_TAG_HUSBAND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }

--- a/src/test/java/seedu/taassist/logic/commands/EditStudentDescriptorTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/EditStudentDescriptorTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taassist.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +52,7 @@ public class EditStudentDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different classes -> returns false
-        editedAmy = new EditStudentDescriptorBuilder(DESC_AMY).withModuleClasses(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditStudentDescriptorBuilder(DESC_AMY).withModuleClasses(VALID_CLASS_HUSBAND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 }

--- a/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
@@ -5,10 +5,10 @@ import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_CLASS_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -65,7 +65,7 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
 
-        // multiple tags - all accepted
+        // multiple classes - all accepted
         Student expectedStudentMultipleTags = new StudentBuilder(BOB)
                 .withModuleClasses(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
@@ -75,7 +75,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
+        // zero classes
         Student expectedStudentNoTag = new StudentBuilder(AMY).withModuleClasses().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedStudentNoTag));
@@ -123,9 +123,9 @@ public class AddCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
-        // invalid tag
+        // invalid class
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, ModuleClass.MESSAGE_CONSTRAINTS);
+                + INVALID_CLASS_DESC + VALID_TAG_FRIEND, ModuleClass.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB,

--- a/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.taassist.logic.parser;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.CLASS_DESC_FRIEND;
+import static seedu.taassist.logic.commands.CommandTestUtil.CLASS_DESC_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_CLASS_DESC;
@@ -15,14 +17,12 @@ import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.taassist.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.taassist.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_FRIEND;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taassist.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.taassist.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.taassist.testutil.TypicalStudents.AMY;
@@ -43,34 +43,34 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Student expectedStudent = new StudentBuilder(BOB).withModuleClasses(VALID_TAG_FRIEND).build();
+        Student expectedStudent = new StudentBuilder(BOB).withModuleClasses(VALID_CLASS_FRIEND).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
+                + ADDRESS_DESC_BOB + CLASS_DESC_FRIEND, new AddCommand(expectedStudent));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
+                + ADDRESS_DESC_BOB + CLASS_DESC_FRIEND, new AddCommand(expectedStudent));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
+                + ADDRESS_DESC_BOB + CLASS_DESC_FRIEND, new AddCommand(expectedStudent));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
+                + ADDRESS_DESC_BOB + CLASS_DESC_FRIEND, new AddCommand(expectedStudent));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedStudent));
+                + ADDRESS_DESC_BOB + CLASS_DESC_FRIEND, new AddCommand(expectedStudent));
 
         // multiple classes - all accepted
         Student expectedStudentMultipleTags = new StudentBuilder(BOB)
-                .withModuleClasses(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_FRIEND, VALID_CLASS_HUSBAND)
                 .build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedStudentMultipleTags));
+                + CLASS_DESC_HUSBAND + CLASS_DESC_FRIEND, new AddCommand(expectedStudentMultipleTags));
     }
 
     @Test
@@ -82,17 +82,17 @@ public class AddCommandParserTest {
 
         // no address
         Student expectedStudentNoAddr = new StudentBuilder(AMY).withAddress("").build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND,
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + CLASS_DESC_FRIEND,
                 new AddCommand(expectedStudentNoAddr));
 
         // no phone
         Student expectedStudentNoPhone = new StudentBuilder(AMY).withPhone("").build();
-        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND,
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + CLASS_DESC_FRIEND,
                 new AddCommand(expectedStudentNoPhone));
 
         // no email
         Student expectedStudentNoEmail = new StudentBuilder(AMY).withEmail("").build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND,
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + CLASS_DESC_FRIEND,
                 new AddCommand(expectedStudentNoEmail));
     }
 
@@ -113,19 +113,19 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + CLASS_DESC_HUSBAND + CLASS_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + CLASS_DESC_HUSBAND + CLASS_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + CLASS_DESC_HUSBAND + CLASS_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid class
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_CLASS_DESC + VALID_TAG_FRIEND, ModuleClass.MESSAGE_CONSTRAINTS);
+                + INVALID_CLASS_DESC + VALID_CLASS_FRIEND, ModuleClass.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB,
@@ -133,7 +133,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + CLASS_DESC_HUSBAND + CLASS_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/taassist/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/ArgumentTokenizerTest.java
@@ -55,7 +55,7 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void tokenize_noPrefixes_allTakenAsPreamble() {
-        String argsString = "  some random string /t tag with leading and trailing spaces ";
+        String argsString = "  some random string /c class with leading and trailing spaces ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed

--- a/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
@@ -5,10 +5,10 @@ import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_CLASS_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
@@ -48,7 +48,7 @@ public class EditCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
-    private EditCommandParser parser = new EditCommandParser();
+    private final EditCommandParser parser = new EditCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -82,7 +82,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, ModuleClass.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_CLASS_DESC, ModuleClass.MESSAGE_CONSTRAINTS); // invalid class
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
@@ -91,8 +91,8 @@ public class EditCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Student} being edited,
-        // parsing it together with a valid tag results in error
+        // while parsing {@code PREFIX_TAG} alone will reset the classes of the {@code Student} being edited,
+        // parsing it together with a valid class results in error
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + MODULE_CLASS_EMPTY,
                 ModuleClass.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + MODULE_CLASS_EMPTY + TAG_DESC_HUSBAND,
@@ -158,7 +158,7 @@ public class EditCommandParserTest {
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // tags
+        // classes
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditStudentDescriptorBuilder().withModuleClasses(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);

--- a/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.taassist.logic.parser;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.CLASS_DESC_FRIEND;
+import static seedu.taassist.logic.commands.CommandTestUtil.CLASS_DESC_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_CLASS_DESC;
@@ -12,17 +14,15 @@ import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.taassist.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_FRIEND;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 import static seedu.taassist.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.taassist.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -93,11 +93,11 @@ public class EditCommandParserTest {
 
         // while parsing {@code PREFIX_TAG} alone will reset the classes of the {@code Student} being edited,
         // parsing it together with a valid class results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + MODULE_CLASS_EMPTY,
+        assertParseFailure(parser, "1" + CLASS_DESC_FRIEND + CLASS_DESC_HUSBAND + MODULE_CLASS_EMPTY,
                 ModuleClass.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + MODULE_CLASS_EMPTY + TAG_DESC_HUSBAND,
+        assertParseFailure(parser, "1" + CLASS_DESC_FRIEND + MODULE_CLASS_EMPTY + CLASS_DESC_HUSBAND,
                 ModuleClass.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + MODULE_CLASS_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+        assertParseFailure(parser, "1" + MODULE_CLASS_EMPTY + CLASS_DESC_FRIEND + CLASS_DESC_HUSBAND,
                 ModuleClass.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
@@ -108,12 +108,12 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_STUDENT;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + CLASS_DESC_HUSBAND
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + CLASS_DESC_FRIEND;
 
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withModuleClasses(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withModuleClasses(VALID_CLASS_HUSBAND, VALID_CLASS_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -159,8 +159,8 @@ public class EditCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // classes
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditStudentDescriptorBuilder().withModuleClasses(VALID_TAG_FRIEND).build();
+        userInput = targetIndex.getOneBased() + CLASS_DESC_FRIEND;
+        descriptor = new EditStudentDescriptorBuilder().withModuleClasses(VALID_CLASS_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -169,12 +169,12 @@ public class EditCommandParserTest {
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_STUDENT;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+                + CLASS_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + CLASS_DESC_FRIEND
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + CLASS_DESC_HUSBAND;
 
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_FRIEND, VALID_CLASS_HUSBAND)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -200,7 +200,7 @@ public class EditCommandParserTest {
     }
 
     @Test
-    public void parse_resetTags_success() {
+    public void parse_resetClasses_success() {
         Index targetIndex = INDEX_THIRD_STUDENT;
         String userInput = targetIndex.getOneBased() + MODULE_CLASS_EMPTY;
 

--- a/src/test/java/seedu/taassist/model/TaAssistTest.java
+++ b/src/test/java/seedu/taassist/model/TaAssistTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.testutil.Assert.assertThrows;
 import static seedu.taassist.testutil.TypicalStudents.ALICE;
 import static seedu.taassist.testutil.TypicalStudents.getTypicalTaAssist;
@@ -48,7 +48,7 @@ public class TaAssistTest {
     public void resetData_withDuplicateStudents_throwsDuplicateStudentException() {
         // Two students with the same identity fields
         Student editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_HUSBAND)
                 .build();
         List<Student> newStudents = Arrays.asList(ALICE, editedAlice);
         List<ModuleClass> newModuleClasses = Arrays.asList(); // TODO: Add test case for classes too
@@ -77,7 +77,7 @@ public class TaAssistTest {
     public void hasStudent_studentWithSameIdentityFieldsInTaAssist_returnsTrue() {
         taAssist.addStudent(ALICE);
         Student editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_HUSBAND)
                 .build();
         assertTrue(taAssist.hasStudent(editedAlice));
     }

--- a/src/test/java/seedu/taassist/model/student/StudentTest.java
+++ b/src/test/java/seedu/taassist/model/student/StudentTest.java
@@ -84,7 +84,7 @@ public class StudentTest {
         editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
-        // different tags -> returns false
+        // different classes -> returns false
         editedAlice = new StudentBuilder(ALICE).withModuleClasses(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
     }

--- a/src/test/java/seedu/taassist/model/student/StudentTest.java
+++ b/src/test/java/seedu/taassist/model/student/StudentTest.java
@@ -3,10 +3,10 @@ package seedu.taassist.model.student;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.taassist.testutil.Assert.assertThrows;
 import static seedu.taassist.testutil.TypicalStudents.ALICE;
 import static seedu.taassist.testutil.TypicalStudents.BOB;
@@ -33,7 +33,7 @@ public class StudentTest {
 
         // same name, all other attributes different -> returns true
         Student editedAlice = new StudentBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withModuleClasses(VALID_TAG_HUSBAND).build();
+                .withAddress(VALID_ADDRESS_BOB).withModuleClasses(VALID_CLASS_HUSBAND).build();
         assertTrue(ALICE.isSameStudent(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -85,7 +85,7 @@ public class StudentTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different classes -> returns false
-        editedAlice = new StudentBuilder(ALICE).withModuleClasses(VALID_TAG_HUSBAND).build();
+        editedAlice = new StudentBuilder(ALICE).withModuleClasses(VALID_CLASS_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/taassist/model/student/UniqueStudentListTest.java
+++ b/src/test/java/seedu/taassist/model/student/UniqueStudentListTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.testutil.Assert.assertThrows;
 import static seedu.taassist.testutil.TypicalStudents.ALICE;
 import static seedu.taassist.testutil.TypicalStudents.BOB;
@@ -43,7 +43,7 @@ public class UniqueStudentListTest {
     public void contains_studentWithSameIdentityFieldsInList_returnsTrue() {
         uniqueStudentList.add(ALICE);
         Student editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_HUSBAND)
                 .build();
         assertTrue(uniqueStudentList.contains(editedAlice));
     }
@@ -87,7 +87,7 @@ public class UniqueStudentListTest {
     public void setStudent_editedStudentHasSameIdentity_success() {
         uniqueStudentList.add(ALICE);
         Student editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
-                .withModuleClasses(VALID_TAG_HUSBAND)
+                .withModuleClasses(VALID_CLASS_HUSBAND)
                 .build();
         uniqueStudentList.setStudent(ALICE, editedAlice);
         UniqueStudentList expectedUniqueStudentList = new UniqueStudentList();

--- a/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
@@ -22,7 +22,7 @@ public class JsonAdaptedStudentTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
-    private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_CLASS = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -101,7 +101,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedModuleClass> invalidTags = new ArrayList<>(VALID_TAGS);
-        invalidTags.add(new JsonAdaptedModuleClass(INVALID_TAG));
+        invalidTags.add(new JsonAdaptedModuleClass(INVALID_CLASS));
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
         assertThrows(IllegalValueException.class, student::toModelType);

--- a/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
@@ -28,7 +28,7 @@ public class JsonAdaptedStudentTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final List<JsonAdaptedModuleClass> VALID_TAGS = BENSON.getModuleClasses().stream()
+    private static final List<JsonAdaptedModuleClass> VALID_CLASSES = BENSON.getModuleClasses().stream()
             .map(JsonAdaptedModuleClass::new)
             .collect(Collectors.toList());
 
@@ -41,14 +41,15 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+            VALID_CLASSES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -56,14 +57,15 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student =
+                new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -71,14 +73,15 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedStudent student =
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -86,24 +89,24 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_CLASSES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_CLASSES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
 
     @Test
-    public void toModelType_invalidTags_throwsIllegalValueException() {
-        List<JsonAdaptedModuleClass> invalidTags = new ArrayList<>(VALID_TAGS);
-        invalidTags.add(new JsonAdaptedModuleClass(INVALID_CLASS));
+    public void toModelType_invalidClasses_throwsIllegalValueException() {
+        List<JsonAdaptedModuleClass> invalidClasses = new ArrayList<>(VALID_CLASSES);
+        invalidClasses.add(new JsonAdaptedModuleClass(INVALID_CLASS));
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidClasses);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 

--- a/src/test/java/seedu/taassist/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/taassist/testutil/StudentBuilder.java
@@ -58,7 +58,8 @@ public class StudentBuilder {
     }
 
     /**
-     * Parses the {@code moduleClasses} into a {@code Set<Tag>} and set it to the {@code Student} that we are building.
+     * Parses the {@code moduleClasses} into a {@code Set<ModuleClass>} and
+     * set it to the {@code Student} that we are building.
      */
     public StudentBuilder withModuleClasses(String ... moduleClasses) {
         this.moduleClasses = SampleDataUtil.getModuleClassSet(moduleClasses);

--- a/src/test/java/seedu/taassist/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taassist/testutil/TypicalStudents.java
@@ -2,14 +2,14 @@ package seedu.taassist.testutil;
 
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_FRIEND;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_CLASS_HUSBAND;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.taassist.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.taassist.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,10 +50,10 @@ public class TypicalStudents {
 
     // Manually added - Student's details found in {@code CommandTestUtil}
     public static final Student AMY = new StudentBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withModuleClasses(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withModuleClasses(VALID_CLASS_FRIEND).build();
     public static final Student BOB = new StudentBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-            .withModuleClasses(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withModuleClasses(VALID_CLASS_HUSBAND, VALID_CLASS_FRIEND)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Resolves #86. 
* Rename "tagged" property in "classes" in the JSON files. 
* Rename left out references to tags to classes. 
* Fix CSS file that uses `tags` class instead of `classes`. 
