### PR TITLE
Add toString method to Index

### DIFF
--- a/src/main/java/seedu/taassist/commons/core/index/Index.java
+++ b/src/main/java/seedu/taassist/commons/core/index/Index.java
@@ -51,4 +51,9 @@ public class Index {
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
     }
+
+    @Override
+    public String toString() {
+        return Integer.toString(getOneBased());
+    }
 }


### PR DESCRIPTION
Added `toString` so that `Index` objects are printed properly

Fixes #107 