### PR TITLE
Check for existence of a class before performing some operations

### DIFF
--- a/src/main/java/seedu/taassist/commons/core/Messages.java
+++ b/src/main/java/seedu/taassist/commons/core/Messages.java
@@ -10,4 +10,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_CLASS_DOES_NOT_EXIST = "The class does not exist: %1$s";
+    public static final String MESSAGE_SOME_CLASSES_DO_NOT_EXIST = "One or more classes do not exist.";
 }

--- a/src/main/java/seedu/taassist/commons/core/Messages.java
+++ b/src/main/java/seedu/taassist/commons/core/Messages.java
@@ -9,5 +9,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
-    public static final String MESSAGE_MODULE_CLASS_DOES_NOT_EXIST = "The module class does not exist";
+    public static final String MESSAGE_CLASS_DOES_NOT_EXIST = "The class does not exist: %1$s";
 }

--- a/src/main/java/seedu/taassist/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_CLASS_DOES_NOT_EXIST;
+import static seedu.taassist.commons.core.Messages.MESSAGE_SOME_CLASSES_DO_NOT_EXIST;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
@@ -56,10 +57,8 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
         }
 
-        for (ModuleClass moduleClass : student.getModuleClasses()) {
-            if (!model.hasModuleClass(moduleClass)) {
-                throw new CommandException(String.format(MESSAGE_CLASS_DOES_NOT_EXIST, moduleClass));
-            }
+        if (!model.hasModuleClasses(student.getModuleClasses())) {
+            throw new CommandException(MESSAGE_SOME_CLASSES_DO_NOT_EXIST);
         }
 
         model.addStudent(student);

--- a/src/main/java/seedu/taassist/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AddCommand.java
@@ -1,7 +1,6 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.taassist.commons.core.Messages.MESSAGE_CLASS_DOES_NOT_EXIST;
 import static seedu.taassist.commons.core.Messages.MESSAGE_SOME_CLASSES_DO_NOT_EXIST;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -11,7 +10,6 @@ import static seedu.taassist.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
-import seedu.taassist.model.moduleclass.ModuleClass;
 import seedu.taassist.model.student.Student;
 
 /**

--- a/src/main/java/seedu/taassist/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AddCommand.java
@@ -1,6 +1,7 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_CLASS_DOES_NOT_EXIST;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
@@ -9,6 +10,7 @@ import static seedu.taassist.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
+import seedu.taassist.model.moduleclass.ModuleClass;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -52,6 +54,12 @@ public class AddCommand extends Command {
 
         if (model.hasStudent(student)) {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
+        }
+
+        for (ModuleClass moduleClass : student.getModuleClasses()) {
+            if (!model.hasModuleClass(moduleClass)) {
+                throw new CommandException(String.format(MESSAGE_CLASS_DOES_NOT_EXIST, moduleClass));
+            }
         }
 
         model.addStudent(student);

--- a/src/main/java/seedu/taassist/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AssignCommand.java
@@ -50,7 +50,8 @@ public class AssignCommand extends Command {
         requireNonNull(model);
 
         if (!model.hasModuleClass(moduleClassToAssign)) {
-            throw new CommandException(Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST);
+            throw new CommandException(String.format(Messages.MESSAGE_CLASS_DOES_NOT_EXIST,
+                    moduleClassToAssign));
         }
 
         List<Student> lastShownList = model.getFilteredStudentList();

--- a/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
@@ -17,6 +17,7 @@ public class ClassCommand extends Command {
             + "Parameters: CLASS_NAME\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
     public static final String MESSAGE_ENTERED_FOCUS_MODE = "Entered focus mode for %s";
+    public static final String MESSAGE_CLASS_NOT_FOUND = "Class not found: %s";
 
     private final ModuleClass targetClass;
 
@@ -30,6 +31,11 @@ public class ClassCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (!model.hasModuleClass(targetClass)) {
+            throw new CommandException(String.format(MESSAGE_CLASS_NOT_FOUND, targetClass));
+        }
+
         model.enterFocusMode(targetClass);
         return new CommandResult(String.format(MESSAGE_ENTERED_FOCUS_MODE, targetClass));
     }

--- a/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
@@ -1,6 +1,7 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_CLASS_DOES_NOT_EXIST;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
@@ -17,7 +18,6 @@ public class ClassCommand extends Command {
             + "Parameters: CLASS_NAME\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
     public static final String MESSAGE_ENTERED_FOCUS_MODE = "Entered focus mode for %s";
-    public static final String MESSAGE_CLASS_NOT_FOUND = "Class not found: %s";
 
     private final ModuleClass targetClass;
 
@@ -33,7 +33,7 @@ public class ClassCommand extends Command {
         requireNonNull(model);
 
         if (!model.hasModuleClass(targetClass)) {
-            throw new CommandException(String.format(MESSAGE_CLASS_NOT_FOUND, targetClass));
+            throw new CommandException(String.format(MESSAGE_CLASS_DOES_NOT_EXIST, targetClass));
         }
 
         model.enterFocusMode(targetClass);

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -34,7 +34,7 @@ public class DeletecCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (!model.hasModuleClass(moduleClass)) {
-            throw new CommandException(Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST);
+            throw new CommandException(String.format(Messages.MESSAGE_CLASS_DOES_NOT_EXIST, moduleClass));
         }
         model.deleteModuleClass(moduleClass);
         return new CommandResult(String.format(MESSAGE_DELETE_MODULE_CLASS_SUCCESS, moduleClass));

--- a/src/main/java/seedu/taassist/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/EditCommand.java
@@ -81,6 +81,10 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
         }
 
+        if (!model.hasModuleClasses(editedStudent.getModuleClasses())) {
+            throw new CommandException(Messages.MESSAGE_SOME_CLASSES_DO_NOT_EXIST);
+        }
+
         model.setStudent(studentToEdit, editedStudent);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(String.format(MESSAGE_EDIT_STUDENT_SUCCESS, editedStudent));

--- a/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
@@ -50,7 +50,8 @@ public class UnassignCommand extends Command {
         requireNonNull(model);
 
         if (!model.hasModuleClass(moduleClassToUnassign)) {
-            throw new CommandException(Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST);
+            throw new CommandException(String.format(Messages.MESSAGE_CLASS_DOES_NOT_EXIST,
+                    moduleClassToUnassign));
         }
 
         List<Student> lastShownList = model.getFilteredStudentList();

--- a/src/main/java/seedu/taassist/model/Model.java
+++ b/src/main/java/seedu/taassist/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.taassist.model;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import javafx.beans.property.SimpleStringProperty;
@@ -92,6 +93,11 @@ public interface Model {
      * Returns true if a class with the same identity as {@code moduleClass} exists in TA-Assist.
      */
     boolean hasModuleClass(ModuleClass moduleClass);
+
+    /**
+     * Returns true if all the classes in {@code moduleClass} exist in TA-Assist.
+     */
+    boolean hasModuleClasses(Collection<ModuleClass> moduleClasses);
 
     /**
      * Deletes the given class.

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -125,6 +126,17 @@ public class ModelManager implements Model {
     public boolean hasModuleClass(ModuleClass moduleClass) {
         requireAllNonNull(moduleClass);
         return taAssist.hasModuleClass(moduleClass);
+    }
+
+    @Override
+    public boolean hasModuleClasses(Collection<ModuleClass> moduleClasses) {
+        requireAllNonNull(moduleClasses);
+        for (ModuleClass moduleClass : moduleClasses) {
+            if (!hasModuleClass(moduleClass)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -131,12 +131,7 @@ public class ModelManager implements Model {
     @Override
     public boolean hasModuleClasses(Collection<ModuleClass> moduleClasses) {
         requireAllNonNull(moduleClasses);
-        for (ModuleClass moduleClass : moduleClasses) {
-            if (!hasModuleClass(moduleClass)) {
-                return false;
-            }
-        }
-        return true;
+        return moduleClasses.stream().allMatch(this::hasModuleClass);
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
@@ -41,26 +41,14 @@ public class SampleDataUtil {
     }
 
     public static ReadOnlyTaAssist getSampleTaAssist() {
-        TaAssist sampleTaAssist = new TaAssist();
-        for (Student sampleStudent : getSampleStudents()) {
-            addModuleClasses(sampleTaAssist, sampleStudent);
-            sampleTaAssist.addStudent(sampleStudent);
+        TaAssist taAssist = new TaAssist();
+        for (Student student : getSampleStudents()) {
+            student.getModuleClasses().stream()
+                    .filter(c -> !taAssist.hasModuleClass(c))
+                    .forEach(taAssist::addModuleClass);
+            taAssist.addStudent(student);
         }
-        return sampleTaAssist;
-    }
-
-    /**
-     * Adds the modules classes of a {@code Student} to a {@code TaAssist} if they do not already exist.
-     *
-     * @param taAssist The {@code TaAssist} to add the {@code ModuleClass} to.
-     * @param student The {@code Student} to get the {@code ModuleClass} from.
-     */
-    private static void addModuleClasses(TaAssist taAssist, Student student) {
-        for (ModuleClass moduleClass : student.getModuleClasses()) {
-            if (!taAssist.hasModuleClass(moduleClass)) {
-                taAssist.addModuleClass(moduleClass);
-            }
-        }
+        return taAssist;
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/taassist/model/util/SampleDataUtil.java
@@ -41,11 +41,26 @@ public class SampleDataUtil {
     }
 
     public static ReadOnlyTaAssist getSampleTaAssist() {
-        TaAssist sampleAb = new TaAssist();
+        TaAssist sampleTaAssist = new TaAssist();
         for (Student sampleStudent : getSampleStudents()) {
-            sampleAb.addStudent(sampleStudent);
+            addModuleClasses(sampleTaAssist, sampleStudent);
+            sampleTaAssist.addStudent(sampleStudent);
         }
-        return sampleAb;
+        return sampleTaAssist;
+    }
+
+    /**
+     * Adds the modules classes of a {@code Student} to a {@code TaAssist} if they do not already exist.
+     *
+     * @param taAssist The {@code TaAssist} to add the {@code ModuleClass} to.
+     * @param student The {@code Student} to get the {@code ModuleClass} from.
+     */
+    private static void addModuleClasses(TaAssist taAssist, Student student) {
+        for (ModuleClass moduleClass : student.getModuleClasses()) {
+            if (!taAssist.hasModuleClass(moduleClass)) {
+                taAssist.addModuleClass(moduleClass);
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
@@ -28,6 +28,7 @@ class JsonAdaptedStudent {
     private final String phone;
     private final String email;
     private final String address;
+    @JsonProperty("classes")
     private final List<JsonAdaptedModuleClass> moduleClasses = new ArrayList<>();
 
     /**

--- a/src/main/java/seedu/taassist/storage/JsonSerializableTaAssist.java
+++ b/src/main/java/seedu/taassist/storage/JsonSerializableTaAssist.java
@@ -22,6 +22,7 @@ class JsonSerializableTaAssist {
 
     public static final String MESSAGE_DUPLICATE_STUDENT = "Students list contains duplicate student(s).";
     public static final String MESSAGE_DUPLICATE_MODULE_CLASS = "Classes list contains duplicate class(es).";
+    public static final String MESSAGE_CLASS_NOT_FOUND = "Class for some student(s) not found in class(es) list.";
 
     private final List<JsonAdaptedStudent> students = new ArrayList<>();
     private final List<JsonAdaptedModuleClass> moduleClasses = new ArrayList<>();
@@ -55,19 +56,24 @@ class JsonSerializableTaAssist {
      */
     public TaAssist toModelType() throws IllegalValueException {
         TaAssist taAssist = new TaAssist();
-        for (JsonAdaptedStudent jsonAdaptedStudent : students) {
-            Student student = jsonAdaptedStudent.toModelType();
-            if (taAssist.hasStudent(student)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_STUDENT);
-            }
-            taAssist.addStudent(student);
-        }
         for (JsonAdaptedModuleClass jsonAdaptedModuleClass : moduleClasses) {
             ModuleClass moduleClass = jsonAdaptedModuleClass.toModelType();
             if (taAssist.hasModuleClass(moduleClass)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE_CLASS);
             }
             taAssist.addModuleClass(moduleClass);
+        }
+        for (JsonAdaptedStudent jsonAdaptedStudent : students) {
+            Student student = jsonAdaptedStudent.toModelType();
+            if (taAssist.hasStudent(student)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_STUDENT);
+            }
+            for (ModuleClass moduleClass : student.getModuleClasses()) {
+                if (!taAssist.hasModuleClass(moduleClass)) {
+                    throw new IllegalValueException(MESSAGE_CLASS_NOT_FOUND);
+                }
+            }
+            taAssist.addStudent(student);
         }
         return taAssist;
     }

--- a/src/test/data/JsonSerializableTaAssistTest/duplicateStudentTaAssist.json
+++ b/src/test/data/JsonSerializableTaAssistTest/duplicateStudentTaAssist.json
@@ -9,7 +9,8 @@
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "classes": [ "family" ]
   } ],
-  "moduleClasses" : []
+  "moduleClasses" : [ "friends", "family" ]
 }

--- a/src/test/data/JsonSerializableTaAssistTest/typicalStudentsTaAssist.json
+++ b/src/test/data/JsonSerializableTaAssistTest/typicalStudentsTaAssist.json
@@ -43,5 +43,5 @@
     "address" : "4th street",
     "classes" : [ ]
   } ],
-  "moduleClasses" : []
+  "moduleClasses" : [ "friends", "owesMoney" ]
 }

--- a/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
@@ -232,6 +232,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasModuleClasses(Collection<ModuleClass> moduleClasses) {
+            return true;
+        }
+
+        @Override
         public void addStudent(Student student) {
             requireNonNull(student);
             studentsAdded.add(student);

--- a/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.taassist.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -152,6 +153,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasModuleClass(ModuleClass moduleClass) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasModuleClasses(Collection<ModuleClass> moduleClasses) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/EditCommandParserTest.java
@@ -91,7 +91,7 @@ public class EditCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the classes of the {@code Student} being edited,
+        // while parsing {@code PREFIX_CLASS} alone will reset the classes of the {@code Student} being edited,
         // parsing it together with a valid class results in error
         assertParseFailure(parser, "1" + CLASS_DESC_FRIEND + CLASS_DESC_HUSBAND + MODULE_CLASS_EMPTY,
                 ModuleClass.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/taassist/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taassist/testutil/TypicalStudents.java
@@ -65,17 +65,15 @@ public class TypicalStudents {
      * Returns an {@code TaAssist} with all the typical students.
      */
     public static TaAssist getTypicalTaAssist() {
-        TaAssist ab = new TaAssist();
+        TaAssist taAssist = new TaAssist();
         for (Student student : getTypicalStudents()) {
-            student.getModuleClasses().forEach(c -> {
-                if (!ab.hasModuleClass(c)) {
-                    ab.addModuleClass(c);
-                }
-            });
-            ab.addStudent(student);
+            student.getModuleClasses().stream()
+                    .filter(c -> !taAssist.hasModuleClass(c))
+                    .forEach(taAssist::addModuleClass);
+            taAssist.addStudent(student);
         }
-        ab.addModuleClass(new ModuleClass(VALID_CLASS_HUSBAND));
-        return ab;
+        taAssist.addModuleClass(new ModuleClass(VALID_CLASS_HUSBAND));
+        return taAssist;
     }
 
     public static List<Student> getTypicalStudents() {

--- a/src/test/java/seedu/taassist/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/taassist/testutil/TypicalStudents.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.taassist.model.TaAssist;
+import seedu.taassist.model.moduleclass.ModuleClass;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -66,8 +67,14 @@ public class TypicalStudents {
     public static TaAssist getTypicalTaAssist() {
         TaAssist ab = new TaAssist();
         for (Student student : getTypicalStudents()) {
+            student.getModuleClasses().forEach(c -> {
+                if (!ab.hasModuleClass(c)) {
+                    ab.addModuleClass(c);
+                }
+            });
             ab.addStudent(student);
         }
+        ab.addModuleClass(new ModuleClass(VALID_CLASS_HUSBAND));
         return ab;
     }
 


### PR DESCRIPTION
Fixes #94, #105, #106, #109.

Changes: 
* In `JsonSerializableTaAssist`, after loading the students and classes, check if each class of each students exists in the loaded classes. 
* In `AddCommand` and `EditCommand`, check if all classes of the student being added/edited is present in the model. Gives message "One or more classes do not exist". 
* Commands accepting only one class will show the class to user if it failed to find it in model. Gives message "The class does not exist: [classname]". 
* Fixes the test cases related to this change. 

Related Change: 
* Enforce student in JSON format to have its module list property name "classes". Previously "classes" or "moduleClasses" both were being accepted. 