### PR TITLE
Sessions: Created session class, added session command and lists command

### DIFF
--- a/src/main/java/seedu/taassist/commons/core/Messages.java
+++ b/src/main/java/seedu/taassist/commons/core/Messages.java
@@ -10,4 +10,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_MODULE_CLASS_DOES_NOT_EXIST = "The module class does not exist";
+    public static final String MESSAGE_NOT_IN_FOCUS_MODE = "%s requires you to be in focus mode to be used!";
 }

--- a/src/main/java/seedu/taassist/commons/core/Messages.java
+++ b/src/main/java/seedu/taassist/commons/core/Messages.java
@@ -10,5 +10,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_MODULE_CLASS_DOES_NOT_EXIST = "The module class does not exist";
-    public static final String MESSAGE_NOT_IN_FOCUS_MODE = "%s requires you to be in focus mode to be used!";
+    public static final String MESSAGE_NOT_IN_FOCUS_MODE = "Usage of %s requires you to be in focus mode to be used!";
 }

--- a/src/main/java/seedu/taassist/logic/commands/BackCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/BackCommand.java
@@ -1,7 +1,9 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
 
+import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
 
@@ -12,14 +14,13 @@ public class BackCommand extends Command {
 
     public static final String COMMAND_WORD = "back";
 
-    public static final String MESSAGE_NOT_IN_FOCUS_MODE = "Not in focus mode";
     public static final String MESSAGE_SUCCESS = "Exited focus mode for %s";
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (!model.isInFocusMode()) {
-            return new CommandResult(MESSAGE_NOT_IN_FOCUS_MODE);
+            throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
         }
         ModuleClass focusedClass = model.getFocusedClass();
         model.exitFocusMode();

--- a/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/ClassCommand.java
@@ -17,6 +17,7 @@ public class ClassCommand extends Command {
             + "Parameters: CLASS_NAME\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
     public static final String MESSAGE_ENTERED_FOCUS_MODE = "Entered focus mode for %s";
+    public static final String MESSAGE_CLASS_NOT_FOUND = "Module named %s is not found";
 
     private final ModuleClass targetClass;
 
@@ -30,6 +31,11 @@ public class ClassCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (!model.hasModuleClass(targetClass)) {
+            throw new CommandException(String.format(MESSAGE_CLASS_NOT_FOUND, targetClass));
+        }
+
         model.enterFocusMode(targetClass);
         return new CommandResult(String.format(MESSAGE_ENTERED_FOCUS_MODE, targetClass));
     }

--- a/src/main/java/seedu/taassist/logic/commands/FocusCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/FocusCommand.java
@@ -1,8 +1,8 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST;
 
-import seedu.taassist.commons.core.Messages;
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
@@ -18,7 +18,6 @@ public class FocusCommand extends Command {
             + "Parameters: CLASS_NAME\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
     public static final String MESSAGE_ENTERED_FOCUS_MODE = "Entered focus mode for %s";
-    public static final String MESSAGE_CLASS_NOT_FOUND = "Module named %s is not found";
 
     private final ModuleClass targetClass;
 
@@ -34,7 +33,7 @@ public class FocusCommand extends Command {
         requireNonNull(model);
 
         if (!model.hasModuleClass(targetClass)) {
-            throw new CommandException(String.format(Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST,
+            throw new CommandException(String.format(MESSAGE_MODULE_CLASS_DOES_NOT_EXIST,
                     model.getModuleClassList()));
         }
 

--- a/src/main/java/seedu/taassist/logic/commands/ListsCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/ListsCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
@@ -27,16 +28,14 @@ public class ListsCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
         }
 
-        String focusedClassName = model.getFocusedClass().className;
+        String focusedClassName = model.getFocusedClass().getClassName();
         List<Session> sessions = model.getFocusedClass().getSessions();
-        StringBuilder result = new StringBuilder(String.format(MESSAGE_LIST_HEADER, focusedClassName));
+        StringJoiner sessionsString = new StringJoiner("\n");
+        sessionsString.add(String.format(MESSAGE_LIST_HEADER, focusedClassName));
         for (int i = 0; i < sessions.size(); i++) {
-            result.append("\n");
-            result.append(Integer.toString(i + 1));
-            result.append(". ");
-            result.append(sessions.get(i));
+            sessionsString.add((i + 1) + ". " + sessions.get(i));
         }
-        return new CommandResult(result.toString());
+        return new CommandResult(sessionsString.toString());
     }
 }
 

--- a/src/main/java/seedu/taassist/logic/commands/ListsCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/ListsCommand.java
@@ -1,0 +1,42 @@
+package seedu.taassist.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
+
+import java.util.List;
+
+import seedu.taassist.logic.commands.exceptions.CommandException;
+import seedu.taassist.model.Model;
+import seedu.taassist.model.session.Session;
+
+/**
+ * Lists all sessions in the focused class to the user.
+ */
+public class ListsCommand extends Command {
+
+    public static final String COMMAND_WORD = "lists";
+
+    public static final String MESSAGE_LIST_HEADER = "Recorded sessions for class %s:";
+
+    @Override
+    // TODO: Rudimentary implementation. Needs to be combined with UI.
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.isInFocusMode()) {
+            throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
+        }
+
+        String focusedClassName = model.getFocusedClass().className;
+        List<Session> sessions = model.getFocusedClass().getSessions();
+        StringBuilder result = new StringBuilder(String.format(MESSAGE_LIST_HEADER, focusedClassName));
+        for (int i = 0; i < sessions.size(); i++) {
+            result.append("\n");
+            result.append(Integer.toString(i + 1));
+            result.append(". ");
+            result.append(sessions.get(i));
+        }
+        return new CommandResult(result.toString());
+    }
+}
+

--- a/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
@@ -1,0 +1,62 @@
+package seedu.taassist.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
+import static seedu.taassist.logic.parser.CliSyntax.PREFIX_SESSION;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.taassist.logic.commands.exceptions.CommandException;
+import seedu.taassist.model.Model;
+import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
+
+/**
+ * Creates Session for a class.
+ */
+public class SessionCommand extends Command {
+
+    public static final String COMMAND_WORD = "session";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a new session for a class. "
+            + "Paramaters: "
+            + PREFIX_SESSION + "SESSION_NAME\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SESSION + "Lab1";
+
+    public static final String MESSAGE_SUCCESS = "New session added: %s";
+    public static final String MESSAGE_SESSION_EXISTS = "Session %s already exists!";
+
+    private final Session session;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Session}.
+     */
+    public SessionCommand(Session session) {
+        requireNonNull(session);
+        this.session = session;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.isInFocusMode()) {
+            throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
+        }
+
+        ModuleClass oldClass = model.getFocusedClass();
+        if (oldClass.hasSession(session)) {
+            throw new CommandException(String.format(MESSAGE_SESSION_EXISTS, session.sessionName));
+        }
+
+        List<Session> newList = new ArrayList<>(oldClass.getSessions());
+        newList.add(session);
+        ModuleClass newClass = new ModuleClass(oldClass.className, newList);
+
+        model.setModuleClass(oldClass, newClass);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, session));
+    }
+}

--- a/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
@@ -31,7 +31,7 @@ public class SessionCommand extends Command {
     private final Session session;
 
     /**
-     * Creates an AddCommand to add the specified {@code Session}.
+     * Creates a SessionCommand to create the specified {@code Session}.
      */
     public SessionCommand(Session session) {
         requireNonNull(session);
@@ -48,12 +48,12 @@ public class SessionCommand extends Command {
 
         ModuleClass oldClass = model.getFocusedClass();
         if (oldClass.hasSession(session)) {
-            throw new CommandException(String.format(MESSAGE_SESSION_EXISTS, session.sessionName));
+            throw new CommandException(String.format(MESSAGE_SESSION_EXISTS, session.getSessionName()));
         }
 
-        List<Session> newList = new ArrayList<>(oldClass.getSessions());
-        newList.add(session);
-        ModuleClass newClass = new ModuleClass(oldClass.className, newList);
+        List<Session> newSessions = new ArrayList<>(oldClass.getSessions());
+        newSessions.add(session);
+        ModuleClass newClass = new ModuleClass(oldClass.getClassName(), newSessions);
 
         model.setModuleClass(oldClass, newClass);
 

--- a/src/main/java/seedu/taassist/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/taassist/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_MODULE_CLASS = new Prefix("c/");
+    public static final Prefix PREFIX_SESSION = new Prefix("s/");
 
 }

--- a/src/main/java/seedu/taassist/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/taassist/logic/parser/ParserUtil.java
@@ -143,10 +143,10 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String moduleClass} into a {@code ModuleClass}.
+     * Parses a {@code String session} into a {@code Session}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code moduleClass} is invalid.
+     * @throws ParseException if the given {@code session} is invalid.
      */
     public static Session parseSession(String session) throws ParseException {
         requireNonNull(session);

--- a/src/main/java/seedu/taassist/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/taassist/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.taassist.commons.core.index.Index;
 import seedu.taassist.commons.util.StringUtil;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 import seedu.taassist.model.student.Address;
 import seedu.taassist.model.student.Email;
 import seedu.taassist.model.student.Name;
@@ -139,5 +140,20 @@ public class ParserUtil {
             moduleClassSet.add(parseModuleClass(moduleClassName));
         }
         return moduleClassSet;
+    }
+
+    /**
+     * Parses a {@code String moduleClass} into a {@code ModuleClass}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code moduleClass} is invalid.
+     */
+    public static Session parseSession(String session) throws ParseException {
+        requireNonNull(session);
+        String trimmedSession = session.trim();
+        if (!Session.isValidSessionName(trimmedSession)) {
+            throw new ParseException(Session.MESSAGE_CONSTRAINTS);
+        }
+        return new Session(session);
     }
 }

--- a/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
@@ -8,13 +8,13 @@ import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.session.Session;
 
 /**
- * Parses input arguments and creates a new SessionCommand object
+ * Parses input arguments and creates a new SessionCommand object.
  */
 public class SessionCommandParser implements Parser<SessionCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the SessionCommand
      * and returns an AssignCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public SessionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SESSION);

--- a/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
@@ -18,20 +18,12 @@ public class SessionCommandParser implements Parser<SessionCommand> {
      */
     public SessionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SESSION);
-        if (!isPrefixPresent(argMultimap) || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.containsPrefixes(PREFIX_SESSION) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SessionCommand.MESSAGE_USAGE));
         }
 
         Session session = ParserUtil.parseSession(argMultimap.getValue(PREFIX_SESSION).get());
 
         return new SessionCommand(session);
-    }
-
-    /**
-     * Returns true if the {@code PREFIX_SESSION} does not contain empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean isPrefixPresent(ArgumentMultimap argumentMultimap) {
-        return argumentMultimap.getValue(PREFIX_SESSION).isPresent();
     }
 }

--- a/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/SessionCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.taassist.logic.parser;
+
+import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taassist.logic.parser.CliSyntax.PREFIX_SESSION;
+
+import seedu.taassist.logic.commands.SessionCommand;
+import seedu.taassist.logic.parser.exceptions.ParseException;
+import seedu.taassist.model.session.Session;
+
+/**
+ * Parses input arguments and creates a new SessionCommand object
+ */
+public class SessionCommandParser implements Parser<SessionCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the SessionCommand
+     * and returns an AssignCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SessionCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SESSION);
+        if (!isPrefixPresent(argMultimap) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SessionCommand.MESSAGE_USAGE));
+        }
+
+        Session session = ParserUtil.parseSession(argMultimap.getValue(PREFIX_SESSION).get());
+
+        return new SessionCommand(session);
+    }
+
+    /**
+     * Returns true if the {@code PREFIX_SESSION} does not contain empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean isPrefixPresent(ArgumentMultimap argumentMultimap) {
+        return argumentMultimap.getValue(PREFIX_SESSION).isPresent();
+    }
+}

--- a/src/main/java/seedu/taassist/logic/parser/TaAssistParser.java
+++ b/src/main/java/seedu/taassist/logic/parser/TaAssistParser.java
@@ -21,6 +21,8 @@ import seedu.taassist.logic.commands.FindCommand;
 import seedu.taassist.logic.commands.HelpCommand;
 import seedu.taassist.logic.commands.ListCommand;
 import seedu.taassist.logic.commands.ListcCommand;
+import seedu.taassist.logic.commands.ListsCommand;
+import seedu.taassist.logic.commands.SessionCommand;
 import seedu.taassist.logic.commands.UnassignCommand;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 
@@ -81,8 +83,14 @@ public class TaAssistParser {
         case UnassignCommand.COMMAND_WORD:
             return new UnassignCommandParser().parse(arguments);
 
+        case SessionCommand.COMMAND_WORD:
+            return new SessionCommandParser().parse(arguments);
+
         case ListcCommand.COMMAND_WORD:
             return new ListcCommand();
+
+        case ListsCommand.COMMAND_WORD:
+            return new ListsCommand();
 
         case ClassCommand.COMMAND_WORD:
             return new ClassCommandParser().parse(arguments);

--- a/src/main/java/seedu/taassist/model/Model.java
+++ b/src/main/java/seedu/taassist/model/Model.java
@@ -100,6 +100,13 @@ public interface Model {
     void deleteModuleClass(ModuleClass moduleClass);
 
     /**
+     * Replaces the module class {@code target} in the list with {@code editedModuleClass}.
+     * {@code target} must exist in the list.
+     * The identity of {@code editedModuleClass} must not be the same as another existing module class in the TaAssist.
+     */
+    void setModuleClass(ModuleClass target, ModuleClass editedModuleClass);
+
+    /**
      * Adds the given class.
      * {@code moduleClass} must not already exist in TA-Assist.
      */

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -199,11 +199,16 @@ public class ModelManager implements Model {
 
     //=========== Handles focus mode state ==================================================================
 
-    // Guarantees: classToFocus must exist in TaAssist.
+    // TODO: Should guarantee classToFocus's equivalent identity module class must exist in TaAssist.
     @Override
     public void enterFocusMode(ModuleClass classToFocus) {
         requireNonNull(classToFocus);
+
+        // This is done as the passed in module class might not be the exact module class needed.
+        // Hence, it should look for the module class with equivalent identity in taAssist.
+        // As it's taAssist's module class that contains the actual Session content.
         this.focusedClass = taAssist.findModuleClass(classToFocus).get();
+
         focusLabelProperty.set(String.format(FOCUS_LABEL_FORMAT, focusedClass));
         IsPartOfClassPredicate predicate = new IsPartOfClassPredicate(focusedClass);
         updateFilteredStudentList(predicate);

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -140,7 +140,7 @@ public class TaAssist implements ReadOnlyTaAssist {
     }
 
     /**
-     * Finds and returns a module class with equivalent identity to {@code target}
+     * Finds and returns a module class with equivalent identity to {@code target}.
      */
     public Optional<ModuleClass> findModuleClass(ModuleClass target) {
         requireNonNull(target);

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -3,6 +3,7 @@ package seedu.taassist.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.taassist.model.moduleclass.ModuleClass;
@@ -125,6 +126,24 @@ public class TaAssist implements ReadOnlyTaAssist {
     public void addModuleClass(ModuleClass moduleClass) {
         requireNonNull(moduleClass);
         moduleClasses.add(moduleClass);
+    }
+
+    /**
+     * Replaces the module class {@code target} in the list with {@code editedModuleClass}.
+     * {@code target} must exist in the list.
+     * The identity of {@code editedModuleClass} must not be the same as another existing module class in the app.
+     */
+    public void setModuleClass(ModuleClass target, ModuleClass editedModuleClass) {
+        requireNonNull(editedModuleClass);
+        moduleClasses.setModuleClass(target, editedModuleClass);
+    }
+
+    /**
+     * Finds and returns a module class with equivalent identity to {@code target}
+     */
+    public Optional<ModuleClass> findModuleClass(ModuleClass target) {
+        requireNonNull(target);
+        return moduleClasses.findModuleClass(target);
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -1,6 +1,7 @@
 package seedu.taassist.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -96,7 +97,7 @@ public class TaAssist implements ReadOnlyTaAssist {
      * book.
      */
     public void setStudent(Student target, Student editedStudent) {
-        requireNonNull(editedStudent);
+        requireAllNonNull(target, editedStudent);
         students.setStudent(target, editedStudent);
     }
 
@@ -134,7 +135,7 @@ public class TaAssist implements ReadOnlyTaAssist {
      * The identity of {@code editedModuleClass} must not be the same as another existing module class in the app.
      */
     public void setModuleClass(ModuleClass target, ModuleClass editedModuleClass) {
-        requireNonNull(editedModuleClass);
+        requireAllNonNull(target, editedModuleClass);
         moduleClasses.setModuleClass(target, editedModuleClass);
     }
 

--- a/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
@@ -2,6 +2,14 @@ package seedu.taassist.model.moduleclass;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.AppUtil.checkArgument;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import seedu.taassist.model.session.Session;
 
 /**
  * Represents a Class in TA-Assist.
@@ -14,6 +22,9 @@ public class ModuleClass {
 
     public final String className;
 
+    // TODO: Implement a more robust solution to check for session uniqueness within the list.
+    private final List<Session> sessions;
+
     /**
      * Constructs a {@code ModuleClass}.
      *
@@ -23,6 +34,20 @@ public class ModuleClass {
         requireNonNull(className);
         checkArgument(isValidModuleClassName(className), MESSAGE_CONSTRAINTS);
         this.className = className;
+        sessions = new ArrayList<Session>();
+    }
+
+    /**
+     * Constructs a {@code ModuleClass} with the provided list of {@code Session}-s
+     *
+     * @param className A valid class name.
+     * @param sessions A list of sessions.
+     */
+    public ModuleClass(String className, List<Session> sessions) {
+        requireAllNonNull(className, sessions);
+        checkArgument(isValidModuleClassName(className), MESSAGE_CONSTRAINTS);
+        this.className = className;
+        this.sessions = sessions;
     }
 
     /**
@@ -32,16 +57,48 @@ public class ModuleClass {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns an immutable sessions list, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public List<Session> getSessions() {
+        return Collections.unmodifiableList(sessions);
+    }
+
+    /**
+     * Returns true if both modules have the same name and session list.
+     * This defines a stronger notion of equality between two module classes.
+     *
+     * @param other the object to be compared to.
+     * @return true if objects are equal.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ModuleClass // instanceof handles nulls
-                && className.equals(((ModuleClass) other).className)); // state check
+                && className.equals(((ModuleClass) other).className)
+                && sessions.equals(((ModuleClass) other).sessions));
+    }
+
+    /**
+     * Returns true if both modules have the same name.
+     * This defines a weaker notion of equality between two module classes.
+     *
+     * @param otherModule the module class to be compared to.
+     * @return true if both modules have the same name.
+     */
+    public boolean isSameModuleClass(ModuleClass otherModule) {
+        return otherModule == this
+            || (otherModule != null && otherModule.className.equals(this.className));
+    }
+
+    public boolean hasSession(Session toCheck) {
+        return sessions.stream().anyMatch(toCheck::isSameSession);
     }
 
     @Override
     public int hashCode() {
-        return className.hashCode();
+        return Objects.hash(className, sessions);
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
@@ -20,7 +20,7 @@ public class ModuleClass {
     public static final String MESSAGE_CONSTRAINTS = "Class names should be alphanumeric";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
-    public final String className;
+    private final String className;
 
     // TODO: Implement a more robust solution to check for session uniqueness within the list.
     private final List<Session> sessions;
@@ -38,7 +38,7 @@ public class ModuleClass {
     }
 
     /**
-     * Constructs a {@code ModuleClass} with the provided list of {@code Session}-s
+     * Constructs a {@code ModuleClass} with the provided list of {@code Session}-s.
      *
      * @param className A valid class name.
      * @param sessions A list of sessions.
@@ -55,6 +55,10 @@ public class ModuleClass {
      */
     public static boolean isValidModuleClassName(String test) { // TODO: Ensure that class exists
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public String getClassName() {
+        return className;
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/moduleclass/UniqueModuleClassList.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/UniqueModuleClassList.java
@@ -3,7 +3,6 @@ package seedu.taassist.model.moduleclass;
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +12,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.taassist.model.moduleclass.exceptions.DuplicateModuleClassException;
 import seedu.taassist.model.moduleclass.exceptions.ModuleClassNotFoundException;
-import seedu.taassist.model.student.exceptions.StudentNotFoundException;
 
 /**
  * A list of classes that enforces uniqueness between its elements and does not allow nulls.
@@ -73,7 +71,7 @@ public class UniqueModuleClassList implements Iterable<ModuleClass> {
 
         int index = internalList.indexOf(target);
         if (index == -1) {
-            throw new StudentNotFoundException();
+            throw new ModuleClassNotFoundException();
         }
 
         if (!target.isSameModuleClass(editedModuleClass) && contains(editedModuleClass)) {
@@ -141,7 +139,14 @@ public class UniqueModuleClassList implements Iterable<ModuleClass> {
      * Returns true if {@code moduleClasses} contains only unique classes.
      */
     private boolean isUniqueListOfModuleClasses(List<ModuleClass> moduleClasses) {
-        return new HashSet<>(moduleClasses).size() == moduleClasses.size();
+        for (int i = 0; i + 1 < moduleClasses.size(); i++) {
+            for (int j = i + 1; j < moduleClasses.size(); j++) {
+                if (moduleClasses.get(i).isSameModuleClass(moduleClasses.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }
 

--- a/src/main/java/seedu/taassist/model/moduleclass/UniqueModuleClassList.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/UniqueModuleClassList.java
@@ -6,11 +6,14 @@ import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.taassist.model.moduleclass.exceptions.DuplicateModuleClassException;
 import seedu.taassist.model.moduleclass.exceptions.ModuleClassNotFoundException;
+import seedu.taassist.model.student.exceptions.StudentNotFoundException;
 
 /**
  * A list of classes that enforces uniqueness between its elements and does not allow nulls.
@@ -34,7 +37,7 @@ public class UniqueModuleClassList implements Iterable<ModuleClass> {
      */
     public boolean contains(ModuleClass toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::isSameModuleClass);
     }
 
     /**
@@ -60,6 +63,26 @@ public class UniqueModuleClassList implements Iterable<ModuleClass> {
         }
     }
 
+    /**
+     * Replaces the module class {@code target} in the list with {@code editedModuleClass}.
+     * {@code target} must exist in the list.
+     * The identity of {@code editedModuleClass} must not be the same as another existing module class in the list.
+     */
+    public void setModuleClass(ModuleClass target, ModuleClass editedModuleClass) {
+        requireAllNonNull(target, editedModuleClass);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new StudentNotFoundException();
+        }
+
+        if (!target.isSameModuleClass(editedModuleClass) && contains(editedModuleClass)) {
+            throw new DuplicateModuleClassException();
+        }
+
+        internalList.set(index, editedModuleClass);
+    }
+
     public void setModuleClasses(UniqueModuleClassList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
@@ -76,6 +99,18 @@ public class UniqueModuleClassList implements Iterable<ModuleClass> {
         }
 
         internalList.setAll(moduleClasses);
+    }
+
+    /**
+     * Finds a module class with equivalent identity to {@code target}.
+     */
+    public Optional<ModuleClass> findModuleClass(ModuleClass target) {
+        requireNonNull(target);
+        List<ModuleClass> result = internalList.stream()
+                .filter(target::isSameModuleClass)
+                .limit(1)
+                .collect(Collectors.toList());
+        return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/session/Session.java
+++ b/src/main/java/seedu/taassist/model/session/Session.java
@@ -8,7 +8,7 @@ import static seedu.taassist.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidSessionName(String)}
  */
 public class Session {
-    public static final String MESSAGE_CONSTRAINTS = "Session names can take any values, but it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Session names can take any values, but they should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -16,12 +16,12 @@ public class Session {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
-    public final String sessionName;
+    private final String sessionName;
 
     /**
      * Constructs a {@code Session}.
      *
-     * @param sessionName A valid class name.
+     * @param sessionName A valid session name.
      */
     public Session(String sessionName) {
         requireNonNull(sessionName);
@@ -34,6 +34,10 @@ public class Session {
      */
     public static boolean isValidSessionName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public String getSessionName() {
+        return sessionName;
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/session/Session.java
+++ b/src/main/java/seedu/taassist/model/session/Session.java
@@ -1,0 +1,59 @@
+package seedu.taassist.model.session;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.util.AppUtil.checkArgument;
+
+import seedu.taassist.model.moduleclass.ModuleClass;
+
+/**
+ * Represents a Session for a {@code ModuleClass} in TA-Assist.
+ * Guarantees: immutable;
+ */
+public class Session {
+    public static final String MESSAGE_CONSTRAINTS = "Session names can take any values, but it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String sessionName;
+
+    /**
+     * Constructs a {@code Session}.
+     *
+     * @param sessionName A valid class name.
+     */
+    public Session(String sessionName) {
+        requireNonNull(sessionName);
+        checkArgument(isValidSessionName(sessionName), MESSAGE_CONSTRAINTS);
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * Returns true if a given string is a valid session name.
+     */
+    public static boolean isValidSessionName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Session // instanceof handles nulls
+                && sessionName.equals(((Session) other).sessionName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return sessionName.hashCode();
+    }
+
+    /**
+     * Formats state as text for viewing.
+     */
+    public String toString() {
+        return sessionName;
+    }
+}

--- a/src/main/java/seedu/taassist/model/session/Session.java
+++ b/src/main/java/seedu/taassist/model/session/Session.java
@@ -3,11 +3,9 @@ package seedu.taassist.model.session;
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.AppUtil.checkArgument;
 
-import seedu.taassist.model.moduleclass.ModuleClass;
-
 /**
  * Represents a Session for a {@code ModuleClass} in TA-Assist.
- * Guarantees: immutable;
+ * Guarantees: immutable; name is valid as declared in {@link #isValidSessionName(String)}
  */
 public class Session {
     public static final String MESSAGE_CONSTRAINTS = "Session names can take any values, but it should not be blank";
@@ -43,6 +41,18 @@ public class Session {
         return other == this // short circuit if same object
                 || (other instanceof Session // instanceof handles nulls
                 && sessionName.equals(((Session) other).sessionName)); // state check
+    }
+
+    /**
+     * Returns true if both sessions have the same name.
+     * This defines a weaker notion of equality between two sessions.
+     *
+     * @param otherSession the session to be compared to.
+     * @return true if both sessions have the same name.
+     */
+    public boolean isSameSession(Session otherSession) {
+        return otherSession == this
+                || (otherSession != null && otherSession.sessionName.equals(sessionName));
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/student/Address.java
+++ b/src/main/java/seedu/taassist/model/student/Address.java
@@ -9,10 +9,10 @@ import static seedu.taassist.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, but they should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the session must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";

--- a/src/main/java/seedu/taassist/model/student/Address.java
+++ b/src/main/java/seedu/taassist/model/student/Address.java
@@ -12,7 +12,7 @@ public class Address {
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, but they should not be blank";
 
     /*
-     * The first character of the session must not be a whitespace,
+     * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
@@ -31,7 +31,7 @@ public class Address {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid address.
      */
     public static boolean isValidAddress(String test) {
         return test.isEmpty() || test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/taassist/model/student/IsPartOfClassPredicate.java
+++ b/src/main/java/seedu/taassist/model/student/IsPartOfClassPredicate.java
@@ -30,7 +30,8 @@ public class IsPartOfClassPredicate implements Predicate<Student> {
      */
     @Override
     public boolean test(Student student) {
-        return student.getModuleClasses().stream().anyMatch(moduleClass -> moduleClass.equals(targetClass));
+        return student.getModuleClasses().stream()
+                .anyMatch(moduleClass -> moduleClass.isSameModuleClass(targetClass));
     }
 
     @Override

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
@@ -1,10 +1,16 @@
 package seedu.taassist.storage;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.taassist.commons.exceptions.IllegalValueException;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 
 /**
  * Json-friendly version of {@link ModuleClass}.
@@ -12,13 +18,19 @@ import seedu.taassist.model.moduleclass.ModuleClass;
 class JsonAdaptedModuleClass {
 
     private final String className;
+    private final List<JsonAdaptedSession> sessions = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonAdaptedModuleClass} with the given {@code className}.
+     * Constructs a {@code JsonAdaptedModuleClass} with the given {@code className} and list
+     * of {@code Session}-s.
      */
     @JsonCreator
-    public JsonAdaptedModuleClass(String className) {
+    public JsonAdaptedModuleClass(@JsonProperty("name") String className,
+                                  @JsonProperty("sessions") List<JsonAdaptedSession> sessions) {
         this.className = className;
+        if (sessions != null) {
+            this.sessions.addAll(sessions);
+        }
     }
 
     /**
@@ -26,11 +38,17 @@ class JsonAdaptedModuleClass {
      */
     public JsonAdaptedModuleClass(ModuleClass source) {
         className = source.className;
+        sessions.addAll(source.getSessions().stream().map(JsonAdaptedSession::new).collect(Collectors.toList()));
     }
 
-    @JsonValue
+    @JsonGetter("name")
     public String getClassName() {
         return className;
+    }
+
+    @JsonGetter("sessions")
+    public List<JsonAdaptedSession> getSessions() {
+        return sessions;
     }
 
     /**
@@ -42,7 +60,12 @@ class JsonAdaptedModuleClass {
         if (!ModuleClass.isValidModuleClassName(className)) {
             throw new IllegalValueException(ModuleClass.MESSAGE_CONSTRAINTS);
         }
-        return new ModuleClass(className);
+
+        List<Session> sessionList = new ArrayList<>();
+        for (JsonAdaptedSession session : sessions) {
+            sessionList.add(session.toModelType());
+        }
+        return new ModuleClass(className, sessionList);
     }
 
 }

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
@@ -37,7 +37,7 @@ class JsonAdaptedModuleClass {
      * Converts a given {@code ModuleClass} into this class for Jackson use.
      */
     public JsonAdaptedModuleClass(ModuleClass source) {
-        className = source.className;
+        className = source.getClassName();
         sessions.addAll(source.getSessions().stream().map(JsonAdaptedSession::new).collect(Collectors.toList()));
     }
 

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedModuleClass.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.taassist.commons.exceptions.IllegalValueException;
@@ -17,7 +16,10 @@ import seedu.taassist.model.session.Session;
  */
 class JsonAdaptedModuleClass {
 
+    @JsonProperty("name")
     private final String className;
+
+    @JsonProperty("sessions")
     private final List<JsonAdaptedSession> sessions = new ArrayList<>();
 
     /**
@@ -39,16 +41,6 @@ class JsonAdaptedModuleClass {
     public JsonAdaptedModuleClass(ModuleClass source) {
         className = source.getClassName();
         sessions.addAll(source.getSessions().stream().map(JsonAdaptedSession::new).collect(Collectors.toList()));
-    }
-
-    @JsonGetter("name")
-    public String getClassName() {
-        return className;
-    }
-
-    @JsonGetter("sessions")
-    public List<JsonAdaptedSession> getSessions() {
-        return sessions;
     }
 
     /**

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
@@ -1,7 +1,6 @@
 package seedu.taassist.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.taassist.commons.exceptions.IllegalValueException;
@@ -12,6 +11,7 @@ import seedu.taassist.model.session.Session;
  */
 class JsonAdaptedSession {
 
+    @JsonProperty("name")
     private final String sessionName;
 
     /**
@@ -27,11 +27,6 @@ class JsonAdaptedSession {
      */
     public JsonAdaptedSession(Session source) {
         this.sessionName = source.getSessionName();
-    }
-
-    @JsonGetter("name")
-    public String getSessionName() {
-        return sessionName;
     }
 
     /**

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
@@ -1,0 +1,48 @@
+package seedu.taassist.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.taassist.commons.exceptions.IllegalValueException;
+import seedu.taassist.model.session.Session;
+
+/**
+ * Json-friendly version of {@link Session}.
+ */
+class JsonAdaptedSession {
+
+    private final String sessionName;
+
+    /**
+     * Contructs a {@code JsonAdaptedSession} with the given {@code sessionName}
+     */
+    @JsonCreator
+    public JsonAdaptedSession(@JsonProperty("name") String sessionName) {
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * Converts a given {@code Session} into this class for Jackson use.
+     */
+    public JsonAdaptedSession(Session source) {
+        this.sessionName = source.sessionName;
+    }
+
+    @JsonGetter("name")
+    public String getSessionName() {
+        return sessionName;
+    }
+
+    /**
+     * Converts this Json-friendly adapted session object into the model's {@code Session} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted session.
+     */
+    public Session toModelType() throws IllegalValueException {
+        if (!Session.isValidSessionName(sessionName)) {
+            throw new IllegalValueException(Session.MESSAGE_CONSTRAINTS);
+        }
+        return new Session(sessionName);
+    }
+}

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedSession.java
@@ -15,7 +15,7 @@ class JsonAdaptedSession {
     private final String sessionName;
 
     /**
-     * Contructs a {@code JsonAdaptedSession} with the given {@code sessionName}
+     * Contructs a {@code JsonAdaptedSession} with the given {@code sessionName}.
      */
     @JsonCreator
     public JsonAdaptedSession(@JsonProperty("name") String sessionName) {
@@ -26,7 +26,7 @@ class JsonAdaptedSession {
      * Converts a given {@code Session} into this class for Jackson use.
      */
     public JsonAdaptedSession(Session source) {
-        this.sessionName = source.sessionName;
+        this.sessionName = source.getSessionName();
     }
 
     @JsonGetter("name")

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.taassist.commons.exceptions.IllegalValueException;
@@ -28,7 +29,7 @@ class JsonAdaptedStudent {
     private final String phone;
     private final String email;
     private final String address;
-    private final List<JsonAdaptedModuleClass> moduleClasses = new ArrayList<>();
+    private final List<String> moduleClasses = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedStudent} with the given student details.
@@ -36,7 +37,7 @@ class JsonAdaptedStudent {
     @JsonCreator
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("classes") List<JsonAdaptedModuleClass> moduleClasses) {
+            @JsonProperty("classes") List<String> moduleClasses) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -55,8 +56,13 @@ class JsonAdaptedStudent {
         email = source.getEmail().value;
         address = source.getAddress().value;
         moduleClasses.addAll(source.getModuleClasses().stream()
-                .map(JsonAdaptedModuleClass::new)
+                .map(x -> x.className)
                 .collect(Collectors.toList()));
+    }
+
+    @JsonGetter("classes")
+    public List<String> getModuleClasses() {
+        return moduleClasses;
     }
 
     /**
@@ -66,8 +72,15 @@ class JsonAdaptedStudent {
      */
     public Student toModelType() throws IllegalValueException {
         final List<ModuleClass> studentModuleClasses = new ArrayList<>();
-        for (JsonAdaptedModuleClass moduleClass : moduleClasses) {
-            studentModuleClasses.add(moduleClass.toModelType());
+        for (String moduleName : moduleClasses) {
+            if (moduleName == null) {
+                throw new IllegalValueException(
+                        String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleClass.class.getSimpleName()));
+            }
+            if (!ModuleClass.isValidModuleClassName(moduleName)) {
+                throw new IllegalValueException(ModuleClass.MESSAGE_CONSTRAINTS);
+            }
+            studentModuleClasses.add(new ModuleClass(moduleName));
         }
 
         if (name == null) {

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.taassist.commons.exceptions.IllegalValueException;
@@ -29,6 +28,8 @@ class JsonAdaptedStudent {
     private final String phone;
     private final String email;
     private final String address;
+
+    @JsonProperty("classes")
     private final List<String> moduleClasses = new ArrayList<>();
 
     /**
@@ -58,11 +59,6 @@ class JsonAdaptedStudent {
         moduleClasses.addAll(source.getModuleClasses().stream()
                 .map(x -> x.getClassName())
                 .collect(Collectors.toList()));
-    }
-
-    @JsonGetter("classes")
-    public List<String> getModuleClasses() {
-        return moduleClasses;
     }
 
     /**

--- a/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/taassist/storage/JsonAdaptedStudent.java
@@ -56,7 +56,7 @@ class JsonAdaptedStudent {
         email = source.getEmail().value;
         address = source.getAddress().value;
         moduleClasses.addAll(source.getModuleClasses().stream()
-                .map(x -> x.className)
+                .map(x -> x.getClassName())
                 .collect(Collectors.toList()));
     }
 
@@ -66,9 +66,9 @@ class JsonAdaptedStudent {
     }
 
     /**
-     * Converts this Jackson-friendly adapted student object into the model's {@code Student} object.
+     * Converts this Jackson-friendly adapted module class object into the model's {@code ModuleClass} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted student.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted module class.
      */
     public Student toModelType() throws IllegalValueException {
         final List<ModuleClass> studentModuleClasses = new ArrayList<>();

--- a/src/main/java/seedu/taassist/ui/StudentCard.java
+++ b/src/main/java/seedu/taassist/ui/StudentCard.java
@@ -53,8 +53,8 @@ public class StudentCard extends UiPart<Region> {
         address.setText(student.getAddress().value);
         email.setText(student.getEmail().value);
         student.getModuleClasses().stream()
-                .sorted(Comparator.comparing(moduleClass -> moduleClass.className))
-                .forEach(moduleClass -> classes.getChildren().add(new Label(moduleClass.className)));
+                .sorted(Comparator.comparing(moduleClass -> moduleClass.getClassName()))
+                .forEach(moduleClass -> classes.getChildren().add(new Label(moduleClass.getClassName())));
     }
 
     @Override

--- a/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/AddCommandTest.java
@@ -165,6 +165,11 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public void setModuleClass(ModuleClass target, ModuleClass editedModuleClass) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         public ObservableList<ModuleClass> getModuleClassList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
@@ -29,7 +29,7 @@ public class JsonAdaptedStudentTest {
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<String> VALID_CLASSES = BENSON.getModuleClasses().stream()
-            .map(x -> x.className)
+            .map(x -> x.getClassName())
             .collect(Collectors.toList());
 
     @Test

--- a/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonAdaptedStudentTest.java
@@ -28,8 +28,8 @@ public class JsonAdaptedStudentTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final List<JsonAdaptedModuleClass> VALID_CLASSES = BENSON.getModuleClasses().stream()
-            .map(JsonAdaptedModuleClass::new)
+    private static final List<String> VALID_CLASSES = BENSON.getModuleClasses().stream()
+            .map(x -> x.className)
             .collect(Collectors.toList());
 
     @Test
@@ -103,8 +103,8 @@ public class JsonAdaptedStudentTest {
 
     @Test
     public void toModelType_invalidClasses_throwsIllegalValueException() {
-        List<JsonAdaptedModuleClass> invalidClasses = new ArrayList<>(VALID_CLASSES);
-        invalidClasses.add(new JsonAdaptedModuleClass(INVALID_CLASS));
+        List<String> invalidClasses = new ArrayList<>(VALID_CLASSES);
+        invalidClasses.add(INVALID_CLASS);
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidClasses);
         assertThrows(IllegalValueException.class, student::toModelType);

--- a/src/test/java/seedu/taassist/testutil/StudentUtil.java
+++ b/src/test/java/seedu/taassist/testutil/StudentUtil.java
@@ -35,7 +35,7 @@ public class StudentUtil {
         sb.append(PREFIX_EMAIL + student.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + student.getAddress().value + " ");
         student.getModuleClasses().stream().forEach(
-            s -> sb.append(PREFIX_MODULE_CLASS + s.className + " ")
+            s -> sb.append(PREFIX_MODULE_CLASS + s.getClassName() + " ")
         );
         return sb.toString();
     }
@@ -54,7 +54,7 @@ public class StudentUtil {
             if (moduleClasses.isEmpty()) {
                 sb.append(PREFIX_MODULE_CLASS);
             } else {
-                moduleClasses.forEach(s -> sb.append(PREFIX_MODULE_CLASS).append(s.className).append(" "));
+                moduleClasses.forEach(s -> sb.append(PREFIX_MODULE_CLASS).append(s.getClassName()).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
Overview:
- Created a `Session`-s class to handle all logic regarding `Session`.
- `ModuleClass` now contains a list of `Session`-s. Note that `ModuleClass` is still immutable.
- `focusedClass` field in `ModelManager` maintains the current list of `Session`-s. 
- Added `session` command to create a session within a focused class.
- Added a rudimentary `lists` command that outputs the current list of sessions to the CLI.
- Currently, `ModuleClass`-es stored in `Student`-s IS **NOT** ALWAYS equals to the `ModuleClass`-es in the `Model`. This is intentional by design, as otherwise, any update to the contents of `ModuleClass`-es would require iterating through all the students to update the data. (again, since `ModuleClass` is immutable). However, they are guaranteed to be "weakly" equal, which is defined by the static method `ModuleClass::isSameModuleClass`.

Things to do (will be added as later issues):
- Make `lists` and `listc` appear in GUI as a split screen view, as shown in the mockup GUI design.
- Enforce uniqueness of `Session` elements in `Classes`. Whilst the commands do check for the existence of `Session`-s before inserting, this doesn't prevent a programmer from accidentally inserting two Session-s with the same name inside the List. Storage checking is also not performed.
- Create lots of tests.

Additional comments:
- Currently, the codebase is a bit confusing, with "weaker" and "stronger" equality concepts, which makes it quite challenging to work around these issues. Perhaps a better idea would be to somehow generalize this idea into a <Key, Value> pair to reduce confusion in code writing and improve code maintainability, i.e. "Students", "Classes", and "Sessions" are "weakly" equal by their name only. This check is actually the more common check throughout the runtime of the app. Any other suggestions on this remark? See issue #122.

Resolves #88, (partially) #115.