### PR TITLE
Fix bug in deleting classes from TA Assist

### DIFF
--- a/src/main/java/seedu/taassist/logic/commands/AddcCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AddcCommand.java
@@ -1,6 +1,7 @@
 package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
 import java.util.HashSet;
@@ -35,7 +36,7 @@ public class AddcCommand extends Command {
      * Creates an AddCommand to add the specified {@code Set&gt;ModuleClass&lt;}.
      */
     public AddcCommand(Set<ModuleClass> moduleClasses) {
-        requireNonNull(moduleClasses);
+        requireAllNonNull(moduleClasses);
         this.moduleClasses = moduleClasses;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeleteCommand.java
@@ -26,7 +26,11 @@ public class DeleteCommand extends Command {
 
     private final Index index;
 
+    /**
+     * Creates a DeleteCommand to delete the student at the given index.
+     */
     public DeleteCommand(Index index) {
+        requireNonNull(index);
         this.index = index;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -45,7 +45,7 @@ public class DeletecCommand extends Command {
                     model.getModuleClassList()));
         }
 
-        List<Student> students = model.getFilteredStudentList();
+        List<Student> students = model.getTaAssist().getStudentList();
         for (Student student : students) {
             if (!Collections.disjoint(student.getModuleClasses(), moduleClasses)) {
                 Set<ModuleClass> assignedClasses = new HashSet<>();

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -2,6 +2,7 @@ package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
 import java.util.Collections;
@@ -33,7 +34,11 @@ public class DeletecCommand extends Command {
 
     private final Set<ModuleClass> moduleClasses;
 
+    /**
+     * Creates a DeletecCommand to delete the given classes.
+     */
     public DeletecCommand(Set<ModuleClass> moduleClasses) {
+        requireAllNonNull(moduleClasses);
         this.moduleClasses = moduleClasses;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -9,10 +9,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.moduleclass.StudentModuleData;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -56,8 +58,14 @@ public class DeletecCommand extends Command {
                 Set<ModuleClass> assignedClasses = new HashSet<>();
                 assignedClasses.addAll(student.getModuleClasses());
                 assignedClasses.removeAll(moduleClasses);
+
+                List<StudentModuleData> studentModuleData = student.getModuleDataList();
+                List<StudentModuleData> updatedModuleData = studentModuleData.stream()
+                        .filter(data -> !assignedClasses.contains(data.getModuleClass()))
+                        .collect(Collectors.toList());
+
                 Student editedStudent = new Student(student.getName(), student.getPhone(), student.getEmail(),
-                        student.getAddress(), assignedClasses);
+                        student.getAddress(), updatedModuleData);
                 model.setStudent(student, editedStudent);
             }
         }

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -4,11 +4,15 @@ import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.student.Student;
 
 /**
  * Deletes a moduleClass identified using it's className from TA-Assist.
@@ -39,6 +43,18 @@ public class DeletecCommand extends Command {
         if (!model.hasModuleClasses(moduleClasses)) {
             throw new CommandException(String.format(MESSAGE_MODULE_CLASS_DOES_NOT_EXIST,
                     model.getModuleClassList()));
+        }
+
+        List<Student> students = model.getFilteredStudentList();
+        for (Student student : students) {
+            if (!Collections.disjoint(student.getModuleClasses(), moduleClasses)) {
+                Set<ModuleClass> assignedClasses = new HashSet<>();
+                assignedClasses.addAll(student.getModuleClasses());
+                assignedClasses.removeAll(moduleClasses);
+                Student editedStudent = new Student(student.getName(), student.getPhone(), student.getEmail(),
+                        student.getAddress(), assignedClasses);
+                model.setStudent(student, editedStudent);
+            }
         }
 
         model.deleteModuleClasses(moduleClasses);

--- a/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
@@ -2,6 +2,7 @@ package seedu.taassist.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_SESSION;
 
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ public class DeletesCommand extends Command {
      * Creates a DeletesCommand to delete the specified {@code Session}s.
      */
     public DeletesCommand(Set<Session> sessions) {
-        requireNonNull(sessions);
+        requireAllNonNull(sessions);
         this.sessions = sessions;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/EditCommand.java
@@ -55,6 +55,8 @@ public class EditCommand extends Command {
     private final EditStudentDescriptor editStudentDescriptor;
 
     /**
+     * Creates an EditCommand to edit the details of the student at the given index.
+     *
      * @param index of the student in the filtered student list to edit.
      * @param editStudentDescriptor details to edit the student with.
      */

--- a/src/main/java/seedu/taassist/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/FindCommand.java
@@ -21,7 +21,11 @@ public class FindCommand extends Command {
 
     private final NameContainsKeywordsPredicate predicate;
 
+    /**
+     * Creates a FindCommand to find students with the given keywords.
+     */
     public FindCommand(NameContainsKeywordsPredicate predicate) {
+        requireNonNull(predicate);
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/FocusCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/FocusCommand.java
@@ -25,6 +25,7 @@ public class FocusCommand extends Command {
      * Creates an FocusCommand that enters focus mode for the specified {@code targetClass}.
      */
     public FocusCommand(ModuleClass targetClass) {
+        requireNonNull(targetClass);
         this.targetClass = targetClass;
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
@@ -3,6 +3,7 @@ package seedu.taassist.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
 import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT_EXIST;
+import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
 import java.util.HashSet;
@@ -40,7 +41,7 @@ public class UnassignCommand extends Command {
      * Creates an UnassignCommand to unassign the given {@Code ModuleClass} from students at the given {@Code Indices}.
      */
     public UnassignCommand(List<Index> indices, ModuleClass moduleClassToUnassign) {
-        requireNonNull(indices);
+        requireAllNonNull(indices);
         requireNonNull(moduleClassToUnassign);
         this.indices = indices;
         this.moduleClassToUnassign = moduleClassToUnassign;


### PR DESCRIPTION
The `deletec` command does not unassign students from the class when it is deleted.
This may cause problems where classes that do not exist in TA Assist are being assigned to students.

Let's change the implementation of `deletec` command so that it unassigns students from the classes that will be deleted.

Closes #87.