### PR TITLE
Fix delete session command and refactor updating of immutable classes

### DIFF
--- a/src/main/java/seedu/taassist/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/AssignCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import seedu.taassist.commons.core.Messages;
@@ -14,7 +13,6 @@ import seedu.taassist.logic.parser.ParserStudentIndexUtil;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
-import seedu.taassist.model.moduleclass.StudentModuleData;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -63,20 +61,7 @@ public class AssignCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
-        for (Student student : studentsToAssign) {
-            if (student.isInModuleClass(moduleClassToAssign)) {
-                continue;
-            }
-            List<StudentModuleData> newModuleData = new ArrayList<>(student.getModuleDataList());
-            newModuleData.add(new StudentModuleData(moduleClassToAssign));
-            Student editedStudent = new Student(
-                    student.getName(),
-                    student.getPhone(),
-                    student.getEmail(),
-                    student.getAddress(),
-                    newModuleData);
-            model.setStudent(student, editedStudent);
-        }
+        studentsToAssign.forEach(s -> model.setStudent(s, s.addModuleClass(moduleClassToAssign)));
 
         String indexOrIndices = indices.size() == 1 ? "index" : "indices";
         return new CommandResult(String.format(MESSAGE_SUCCESS, indexOrIndices, indices, moduleClassToAssign));

--- a/src/main/java/seedu/taassist/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeleteCommand.java
@@ -44,7 +44,7 @@ public class DeleteCommand extends Command {
         }
 
         Student studentToDelete = lastShownList.get(index.getZeroBased());
-        model.deleteStudent(studentToDelete);
+        model.removeStudent(studentToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete));
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -5,17 +5,11 @@ import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
-import seedu.taassist.model.moduleclass.StudentModuleData;
-import seedu.taassist.model.student.Student;
 
 /**
  * Deletes a moduleClass identified using it's className from TA-Assist.
@@ -50,25 +44,6 @@ public class DeletecCommand extends Command {
         if (!model.hasModuleClasses(moduleClasses)) {
             throw new CommandException(String.format(MESSAGE_MODULE_CLASS_DOES_NOT_EXIST,
                     model.getModuleClassList()));
-        }
-
-        List<Student> students = model.getStudentList();
-        for (Student student : students) {
-            if (!Collections.disjoint(student.getModuleClasses(), moduleClasses)) {
-                Set<ModuleClass> assignedClasses = new HashSet<>();
-                assignedClasses.addAll(student.getModuleClasses());
-                assignedClasses.removeAll(moduleClasses);
-
-                // assignedClasses now contains only existing
-                List<StudentModuleData> studentModuleData = student.getModuleDataList();
-                List<StudentModuleData> updatedModuleData = studentModuleData.stream()
-                        .filter(data -> assignedClasses.contains(data.getModuleClass()))
-                        .collect(Collectors.toList());
-
-                Student editedStudent = new Student(student.getName(), student.getPhone(), student.getEmail(),
-                        student.getAddress(), updatedModuleData);
-                model.setStudent(student, editedStudent);
-            }
         }
 
         model.deleteModuleClasses(moduleClasses);

--- a/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletecCommand.java
@@ -46,7 +46,7 @@ public class DeletecCommand extends Command {
                     model.getModuleClassList()));
         }
 
-        model.deleteModuleClasses(moduleClasses);
+        model.removeModuleClasses(moduleClasses);
         return new CommandResult(String.format(MESSAGE_DELETE_MODULE_CLASS_SUCCESS, moduleClasses));
     }
 

--- a/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
@@ -5,8 +5,6 @@ import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_SESSION;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import seedu.taassist.logic.commands.exceptions.CommandException;
@@ -48,18 +46,12 @@ public class DeletesCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
         }
 
-        ModuleClass oldClass = model.getFocusedClass();
-        for (Session session : sessions) {
-            if (!oldClass.hasSession(session)) {
-                throw new CommandException(String.format(MESSAGE_SESSION_DOES_NOT_EXIST, session.getSessionName()));
-            }
+        ModuleClass focusedClass = model.getFocusedClass();
+        if (!sessions.stream().allMatch(focusedClass::hasSession)) {
+            throw new CommandException(String.format(MESSAGE_SESSION_DOES_NOT_EXIST, sessions));
         }
 
-        List<Session> newSessions = new ArrayList<>(oldClass.getSessions());
-        newSessions.removeAll(sessions);
-        ModuleClass newClass = new ModuleClass(oldClass.getClassName(), newSessions);
-
-        model.setModuleClass(oldClass, newClass);
+        model.removeSession(focusedClass, sessions);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, sessions));
     }

--- a/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/DeletesCommand.java
@@ -51,7 +51,7 @@ public class DeletesCommand extends Command {
             throw new CommandException(String.format(MESSAGE_SESSION_DOES_NOT_EXIST, sessions));
         }
 
-        model.removeSession(focusedClass, sessions);
+        model.removeSessions(focusedClass, sessions);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, sessions));
     }

--- a/src/main/java/seedu/taassist/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/GradeCommand.java
@@ -74,7 +74,7 @@ public class GradeCommand extends Command {
         }
 
         for (Student oldStudent : oldStudents) {
-            Student newStudent = Student.getUpdatedStudent(oldStudent, focusedClass, session, grade);
+            Student newStudent = oldStudent.updateModuleSessionGrade(focusedClass, session, grade);
             model.setStudent(oldStudent, newStudent);
         }
 

--- a/src/main/java/seedu/taassist/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/GradeCommand.java
@@ -74,7 +74,7 @@ public class GradeCommand extends Command {
         }
 
         for (Student oldStudent : oldStudents) {
-            Student newStudent = oldStudent.updateModuleSessionGrade(focusedClass, session, grade);
+            Student newStudent = oldStudent.updateGrade(focusedClass, session, grade);
             model.setStudent(oldStudent, newStudent);
         }
 

--- a/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/SessionCommand.java
@@ -5,9 +5,6 @@ import static seedu.taassist.commons.core.Messages.MESSAGE_NOT_IN_FOCUS_MODE;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_SESSION;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import seedu.taassist.logic.commands.exceptions.CommandException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
@@ -49,16 +46,12 @@ public class SessionCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NOT_IN_FOCUS_MODE, COMMAND_WORD));
         }
 
-        ModuleClass oldClass = model.getFocusedClass();
-        if (oldClass.hasSession(session)) {
+        ModuleClass focusedClass = model.getFocusedClass();
+        if (focusedClass.hasSession(session)) {
             throw new CommandException(String.format(MESSAGE_SESSION_EXISTS, session.getSessionName()));
         }
 
-        List<Session> newSessions = new ArrayList<>(oldClass.getSessions());
-        newSessions.add(session);
-        ModuleClass newClass = new ModuleClass(oldClass.getClassName(), newSessions);
-
-        model.setModuleClass(oldClass, newClass);
+        model.setModuleClass(focusedClass, focusedClass.addSession(session));
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, session));
     }

--- a/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
+++ b/src/main/java/seedu/taassist/logic/commands/UnassignCommand.java
@@ -6,7 +6,6 @@ import static seedu.taassist.commons.core.Messages.MESSAGE_MODULE_CLASS_DOES_NOT
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.taassist.logic.parser.CliSyntax.PREFIX_MODULE_CLASS;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import seedu.taassist.commons.core.index.Index;
@@ -15,7 +14,6 @@ import seedu.taassist.logic.parser.ParserStudentIndexUtil;
 import seedu.taassist.logic.parser.exceptions.ParseException;
 import seedu.taassist.model.Model;
 import seedu.taassist.model.moduleclass.ModuleClass;
-import seedu.taassist.model.moduleclass.StudentModuleData;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -64,18 +62,7 @@ public class UnassignCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
-        for (Student student : studentsToUnassign) {
-            List<StudentModuleData> newModuleData = student.getModuleDataList().stream()
-                    .filter(moduleData -> !moduleData.getModuleClass().isSame(moduleClassToUnassign))
-                    .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
-            Student editedStudent = new Student(
-                    student.getName(),
-                    student.getPhone(),
-                    student.getEmail(),
-                    student.getAddress(),
-                    newModuleData);
-            model.setStudent(student, editedStudent);
-        }
+        studentsToUnassign.forEach(s -> model.setStudent(s, s.removeModuleClass(moduleClassToUnassign)));
 
         String indexOrIndices = indices.size() == 1 ? "index" : "indices";
         return new CommandResult(String.format(MESSAGE_SUCCESS, indexOrIndices, indices, moduleClassToUnassign));

--- a/src/main/java/seedu/taassist/model/Model.java
+++ b/src/main/java/seedu/taassist/model/Model.java
@@ -2,12 +2,14 @@ package seedu.taassist.model;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ObservableList;
 import seedu.taassist.commons.core.GuiSettings;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -64,7 +66,7 @@ public interface Model {
      * Deletes the given student.
      * The student must exist in TA-Assist.
      */
-    void deleteStudent(Student target);
+    void removeStudent(Student target);
 
     /**
      * Adds the given student.
@@ -104,7 +106,7 @@ public interface Model {
      * Deletes the given class.
      * The class must exist in TA-Assist.
      */
-    void deleteModuleClass(ModuleClass moduleClass);
+    void removeModuleClass(ModuleClass moduleClass);
 
     /**
      * Replaces the module class {@code target} in the list with {@code editedModuleClass}.
@@ -117,7 +119,17 @@ public interface Model {
      * Deletes multiple classes.
      * The classes must exist in TA-Assist.
      */
-    void deleteModuleClasses(Collection<ModuleClass> moduleClasses);
+    void removeModuleClasses(Collection<ModuleClass> moduleClasses);
+
+    /**
+     * Removes the specified {@code session} from the specified {@code moduleClass}.
+     */
+    void removeSession(ModuleClass moduleClass, Session session);
+
+    /**
+     * Removes the specified {@code sessions} from the specified {@code moduleClass}.
+     */
+    void removeSession(ModuleClass moduleClass, Set<Session> sessions);
 
     /**
      * Adds the given class.
@@ -141,4 +153,5 @@ public interface Model {
     ModuleClass getFocusedClass();
 
     SimpleStringProperty getFocusLabelProperty();
+
 }

--- a/src/main/java/seedu/taassist/model/Model.java
+++ b/src/main/java/seedu/taassist/model/Model.java
@@ -103,17 +103,17 @@ public interface Model {
     boolean hasModuleClasses(Collection<ModuleClass> moduleClasses);
 
     /**
-     * Deletes the given class.
-     * The class must exist in TA-Assist.
-     */
-    void removeModuleClass(ModuleClass moduleClass);
-
-    /**
      * Replaces the module class {@code target} in the list with {@code editedModuleClass}.
      * {@code target} must exist in the list.
      * The identity of {@code editedModuleClass} must not be the same as another existing module class in the TaAssist.
      */
     void setModuleClass(ModuleClass target, ModuleClass editedModuleClass);
+
+    /**
+     * Deletes the given {@code moduleClass}.
+     * The class must exist in TA-Assist.
+     */
+    void removeModuleClass(ModuleClass moduleClass);
 
     /**
      * Deletes multiple classes.
@@ -129,7 +129,7 @@ public interface Model {
     /**
      * Removes the specified {@code sessions} from the specified {@code moduleClass}.
      */
-    void removeSession(ModuleClass moduleClass, Set<Session> sessions);
+    void removeSessions(ModuleClass moduleClass, Set<Session> sessions);
 
     /**
      * Adds the given class.

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -14,6 +15,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.taassist.commons.core.GuiSettings;
 import seedu.taassist.commons.core.LogsCenter;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 import seedu.taassist.model.student.IsPartOfClassPredicate;
 import seedu.taassist.model.student.Student;
 
@@ -106,7 +108,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteStudent(Student target) {
+    public void removeStudent(Student target) {
         requireNonNull(target);
         taAssist.removeStudent(target);
     }
@@ -137,7 +139,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteModuleClass(ModuleClass target) {
+    public void removeModuleClass(ModuleClass target) {
         requireNonNull(target);
         taAssist.removeModuleClass(target);
 
@@ -158,9 +160,25 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
+    public void removeModuleClasses(Collection<ModuleClass> moduleClasses) {
         requireAllNonNull(moduleClasses);
-        moduleClasses.forEach(this::deleteModuleClass);
+        moduleClasses.forEach(this::removeModuleClass);
+    }
+
+    @Override
+    public void removeSession(ModuleClass moduleClass, Session session) {
+        requireAllNonNull(moduleClass, session);
+        taAssist.removeSession(moduleClass, session);
+
+        if (moduleClass.isSame(focusedClass)) {
+            enterFocusMode(moduleClass);
+        }
+    }
+
+    @Override
+    public void removeSession(ModuleClass moduleClass, Set<Session> sessions) {
+        requireAllNonNull(moduleClass, sessions);
+        sessions.forEach(session -> removeSession(moduleClass, session));
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -143,7 +143,6 @@ public class ModelManager implements Model {
         requireNonNull(target);
         taAssist.removeModuleClass(target);
 
-        // TODO: Should an Exception be thrown instead?
         if (target.isSame(focusedClass)) {
             exitFocusMode();
         }
@@ -176,7 +175,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void removeSession(ModuleClass moduleClass, Set<Session> sessions) {
+    public void removeSessions(ModuleClass moduleClass, Set<Session> sessions) {
         requireAllNonNull(moduleClass, sessions);
         sessions.forEach(session -> removeSession(moduleClass, session));
     }

--- a/src/main/java/seedu/taassist/model/ModelManager.java
+++ b/src/main/java/seedu/taassist/model/ModelManager.java
@@ -160,9 +160,7 @@ public class ModelManager implements Model {
     @Override
     public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
         requireAllNonNull(moduleClasses);
-        for (ModuleClass moduleClass : moduleClasses) {
-            deleteModuleClass(moduleClass);
-        }
+        moduleClasses.forEach(this::deleteModuleClass);
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -149,7 +149,6 @@ public class TaAssist implements ReadOnlyTaAssist {
 
     /**
      * Removes {@code moduleClass} from this {@code TaAssist} and unassigns all students in the class.
-     * {@code moduleClass} must exist in TA-Assist.
      */
     public void removeModuleClass(ModuleClass moduleClass) {
         requireNonNull(moduleClass);
@@ -164,7 +163,6 @@ public class TaAssist implements ReadOnlyTaAssist {
     /**
      * Removes the {@code session} from the {@code moduleClass}
      * as well as all students in the {@code moduleClass}.
-     * {@code moduleClass} must exist in TA-Assist.
      */
     public void removeSession(ModuleClass moduleClass, Session session) {
         requireAllNonNull(moduleClass, session);

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 import seedu.taassist.model.student.Student;
 import seedu.taassist.model.uniquelist.UniqueList;
 
@@ -159,6 +160,21 @@ public class TaAssist implements ReadOnlyTaAssist {
         setStudents(updatedStudents);
     }
 
+
+    /**
+     * Removes the {@code session} from the {@code moduleClass}
+     * as well as all students in the {@code moduleClass}.
+     * {@code moduleClass} must exist in TA-Assist.
+     */
+    public void removeSession(ModuleClass moduleClass, Session session) {
+        requireAllNonNull(moduleClass, session);
+        List<Student> updatedStudents = students.asUnmodifiableObservableList().stream()
+                .map(student -> student.removeSession(moduleClass, session))
+                .collect(Collectors.toList());
+        setStudents(updatedStudents);
+        setModuleClass(moduleClass, moduleClass.removeSession(session));
+    }
+
     //// util methods
 
     @Override
@@ -189,4 +205,5 @@ public class TaAssist implements ReadOnlyTaAssist {
     public int hashCode() {
         return students.hashCode();
     }
+
 }

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.taassist.model.moduleclass.ModuleClass;
@@ -146,12 +147,16 @@ public class TaAssist implements ReadOnlyTaAssist {
     }
 
     /**
-     * Removes {@code moduleClass} from this {@code TaAssist}.
+     * Removes {@code moduleClass} from this {@code TaAssist} and unassigns all students in the class.
      * {@code moduleClass} must exist in TA-Assist.
      */
     public void removeModuleClass(ModuleClass moduleClass) {
         requireNonNull(moduleClass);
         moduleClasses.remove(moduleClass);
+        List<Student> updatedStudents = students.asUnmodifiableObservableList().stream()
+                .map(student -> student.removeModuleClass(moduleClass))
+                .collect(Collectors.toList());
+        setStudents(updatedStudents);
     }
 
     //// util methods

--- a/src/main/java/seedu/taassist/model/TaAssist.java
+++ b/src/main/java/seedu/taassist/model/TaAssist.java
@@ -149,6 +149,7 @@ public class TaAssist implements ReadOnlyTaAssist {
 
     /**
      * Removes {@code moduleClass} from this {@code TaAssist} and unassigns all students in the class.
+     * The {@code moduleClass} must exist in TA-Assist.
      */
     public void removeModuleClass(ModuleClass moduleClass) {
         requireNonNull(moduleClass);

--- a/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
@@ -71,6 +71,15 @@ public class ModuleClass implements Identity<ModuleClass> {
     }
 
     /**
+     * Returns a new {@code ModuleClass} by removing the {@code session}.
+     */
+    public ModuleClass removeSession(Session session) {
+        List<Session> newSessions = new ArrayList<>(sessions);
+        newSessions.remove(session);
+        return new ModuleClass(className, newSessions);
+    }
+
+    /**
      * Returns true if both modules have the same name and session list.
      * This defines a stronger notion of equality between two module classes.
      *
@@ -113,4 +122,5 @@ public class ModuleClass implements Identity<ModuleClass> {
     public String toString() {
         return '[' + className + ']';
     }
+
 }

--- a/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
@@ -71,9 +71,24 @@ public class ModuleClass implements Identity<ModuleClass> {
     }
 
     /**
+     * Returns a new {@code ModuleClass} by adding the provided {@code Session}.
+     * If the session already exists, the original {@code ModuleClass} is returned.
+     */
+    public ModuleClass addSession(Session session) {
+        requireNonNull(session);
+        if (hasSession(session)) {
+            return this;
+        }
+        List<Session> newSessions = new ArrayList<>(sessions);
+        newSessions.add(session);
+        return new ModuleClass(className, newSessions);
+    }
+
+    /**
      * Returns a new {@code ModuleClass} by removing the {@code session}.
      */
     public ModuleClass removeSession(Session session) {
+        requireNonNull(session);
         List<Session> newSessions = new ArrayList<>(sessions);
         newSessions.remove(session);
         return new ModuleClass(className, newSessions);

--- a/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/ModuleClass.java
@@ -71,8 +71,8 @@ public class ModuleClass implements Identity<ModuleClass> {
     }
 
     /**
-     * Returns a new {@code ModuleClass} by adding the provided {@code Session}.
-     * If the session already exists, the original {@code ModuleClass} is returned.
+     * Returns a new {@code ModuleClass} by adding the provided {@code Session} to this {@code ModuleClass}.
+     * If the session already exists, this {@code ModuleClass} is returned.
      */
     public ModuleClass addSession(Session session) {
         requireNonNull(session);

--- a/src/main/java/seedu/taassist/model/moduleclass/StudentModuleData.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/StudentModuleData.java
@@ -63,7 +63,7 @@ public class StudentModuleData implements Identity<StudentModuleData> {
      * Returns a new {@code StudentModuleData} by updating the grade in the given {@code session}.
      * If the session does not exist in the list of session data, a new session data is added.
      */
-    public StudentModuleData updateSessionGrade(Session session, double grade) {
+    public StudentModuleData updateGrade(Session session, double grade) {
         requireAllNonNull(session);
         StudentModuleData newStudentModuleData = removeSession(session);
         newStudentModuleData.sessionDataList.add(new SessionData(session, grade));

--- a/src/main/java/seedu/taassist/model/moduleclass/StudentModuleData.java
+++ b/src/main/java/seedu/taassist/model/moduleclass/StudentModuleData.java
@@ -49,20 +49,25 @@ public class StudentModuleData implements Identity<StudentModuleData> {
     }
 
     /**
-     * Returns a list of module data by updating {@code oldModuleData} by changing the grade of
-     * {@code session} in {@code moduleClass} to the new {@code grade}.
+     * Returns a new {@code StudentModuleData} by removing the given session from the list of session data.
      */
-    public static List<StudentModuleData> getUpdatedModuleDataList(List<StudentModuleData> oldModuleData,
-            ModuleClass moduleClass, Session session, double grade) {
-        requireAllNonNull(oldModuleData, moduleClass, session);
-        return oldModuleData.stream().map(moduleData -> {
-            if (moduleData.getModuleClass().isSame(moduleClass)) {
-                return new StudentModuleData(moduleClass, SessionData.getUpdatedSessionDataList(
-                        moduleData.getSessionDataList(), session, grade));
-            } else {
-                return moduleData;
-            }
-        }).collect(Collectors.toList());
+    public StudentModuleData removeSession(Session session) {
+        requireNonNull(session);
+        List<SessionData> newSessionDataList = sessionDataList.asUnmodifiableObservableList().stream()
+                .filter(sessionData -> !sessionData.getSession().equals(session))
+                .collect(Collectors.toList());
+        return new StudentModuleData(moduleClass, newSessionDataList);
+    }
+
+    /**
+     * Returns a new {@code StudentModuleData} by updating the grade in the given {@code session}.
+     * If the session does not exist in the list of session data, a new session data is added.
+     */
+    public StudentModuleData updateSessionGrade(Session session, double grade) {
+        requireAllNonNull(session);
+        StudentModuleData newStudentModuleData = removeSession(session);
+        newStudentModuleData.sessionDataList.add(new SessionData(session, grade));
+        return newStudentModuleData;
     }
 
     @Override

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -86,7 +86,8 @@ public class Student implements Identity<Student> {
     }
 
     /**
-     * Returns a student by removing the {@code StudentModuleData} of the student for the given {@code ModuleClass}.
+     * Returns a new student by removing the {@code StudentModuleData} of
+     * this student for the given {@code ModuleClass}.
      */
     public Student removeModuleClass(ModuleClass moduleClass) {
         List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
@@ -96,20 +97,15 @@ public class Student implements Identity<Student> {
     }
 
     /**
-     * Returns a student by updating {@code oldStudent}'s grade for the given {@code session} in {@code moduleClass}.
+     * Returns a new student by updating this student's grade for the
+     * given {@code session} in {@code moduleClass}.
      */
-    public static Student getUpdatedStudent(Student oldStudent,
-            ModuleClass moduleClass, Session session, double grade) {
-        requireAllNonNull(oldStudent, moduleClass, session);
-        List<StudentModuleData> oldModuleDataList = oldStudent.getModuleDataList();
-        List<StudentModuleData> newModuleDataList =
-                StudentModuleData.getUpdatedModuleDataList(oldModuleDataList, moduleClass, session, grade);
-        return new Student(
-                oldStudent.getName(),
-                oldStudent.getPhone(),
-                oldStudent.getEmail(),
-                oldStudent.getAddress(),
-                newModuleDataList);
+    public Student updateModuleSessionGrade(ModuleClass moduleClass, Session session, double grade) {
+        requireAllNonNull(moduleClass, session);
+        List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
+                .map(d -> d.getModuleClass().isSame(moduleClass) ? d.updateSessionGrade(session, grade) : d)
+                .collect(Collectors.toList());
+        return new Student(name, phone, email, address, updatedModuleData);
     }
 
     /**

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -88,7 +88,7 @@ public class Student implements Identity<Student> {
 
     /**
      * Returns a new student by adding the given {@code moduleClass} to the student's module data.
-     * If the student is already enrolled in the module class returned.
+     * If the student is already enrolled in the module class, the same student is returned.
      */
     public Student addModuleClass(ModuleClass moduleClass) {
         requireNonNull(moduleClass);
@@ -113,7 +113,8 @@ public class Student implements Identity<Student> {
     }
 
     /**
-     * Returns a new student by removing the data for the given {@code session} in {@code moduleClass}
+     * Returns a new student by removing this student's data for the given
+     * {@code session} in {@code moduleClass}.
      */
     public Student removeSession(ModuleClass moduleClass, Session session) {
         requireAllNonNull(moduleClass, session);

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -86,6 +86,16 @@ public class Student implements Identity<Student> {
     }
 
     /**
+     * Returns a student by removing the {@code StudentModuleData} of the student for the given {@code ModuleClass}.
+     */
+    public Student removeModuleClass(ModuleClass moduleClass) {
+        List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
+                .filter(data -> !data.getModuleClass().isSame(moduleClass))
+                .collect(Collectors.toList());
+        return new Student(name, phone, email, address, updatedModuleData);
+    }
+
+    /**
      * Returns a student by updating {@code oldStudent}'s grade for the given {@code session} in {@code moduleClass}.
      */
     public static Student getUpdatedStudent(Student oldStudent,

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -74,7 +74,7 @@ public class Student implements Identity<Student> {
     /**
      * Returns true if the Student is assigned to the provided {@code moduleClass}.
      */
-    public boolean isInModuleClass(ModuleClass moduleClass) {
+    private boolean isInModuleClass(ModuleClass moduleClass) {
         return moduleDataList.contains(new StudentModuleData(moduleClass));
     }
 
@@ -86,8 +86,21 @@ public class Student implements Identity<Student> {
     }
 
     /**
-     * Returns a new student by removing the {@code StudentModuleData} of
-     * this student for the given {@code ModuleClass}.
+     * Returns a new student by adding the given {@code moduleClass} to the student's module data.
+     * If the student is already enrolled in the module class returned.
+     */
+    public Student addModuleClass(ModuleClass moduleClass) {
+        if (isInModuleClass(moduleClass)) {
+            return this;
+        }
+        Student newStudent = new Student(name, phone, email, address, moduleDataList.asUnmodifiableObservableList());
+        newStudent.moduleDataList.add(new StudentModuleData(moduleClass));
+        return newStudent;
+    }
+
+    /**
+     * Returns a new student by removing the {@code StudentModuleData}
+     * of this student for the given {@code ModuleClass}.
      */
     public Student removeModuleClass(ModuleClass moduleClass) {
         List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -110,10 +110,10 @@ public class Student implements Identity<Student> {
      * Returns a new student by updating this student's grade for the
      * given {@code session} in {@code moduleClass}.
      */
-    public Student updateModuleSessionGrade(ModuleClass moduleClass, Session session, double grade) {
+    public Student updateGrade(ModuleClass moduleClass, Session session, double grade) {
         requireAllNonNull(moduleClass, session);
         List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
-                .map(d -> d.getModuleClass().isSame(moduleClass) ? d.updateSessionGrade(session, grade) : d)
+                .map(d -> d.getModuleClass().isSame(moduleClass) ? d.updateGrade(session, grade) : d)
                 .collect(Collectors.toList());
         return new Student(name, phone, email, address, updatedModuleData);
     }

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -1,5 +1,6 @@
 package seedu.taassist.model.student;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.taassist.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
@@ -90,6 +91,7 @@ public class Student implements Identity<Student> {
      * If the student is already enrolled in the module class returned.
      */
     public Student addModuleClass(ModuleClass moduleClass) {
+        requireNonNull(moduleClass);
         if (isInModuleClass(moduleClass)) {
             return this;
         }
@@ -103,6 +105,7 @@ public class Student implements Identity<Student> {
      * of this student for the given {@code ModuleClass}.
      */
     public Student removeModuleClass(ModuleClass moduleClass) {
+        requireNonNull(moduleClass);
         List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
                 .filter(data -> !data.getModuleClass().isSame(moduleClass))
                 .collect(Collectors.toList());
@@ -113,6 +116,7 @@ public class Student implements Identity<Student> {
      * Returns a new student by removing the data for the given {@code session} in {@code moduleClass}
      */
     public Student removeSession(ModuleClass moduleClass, Session session) {
+        requireAllNonNull(moduleClass, session);
         List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
             .map(d -> d.getModuleClass().isSame(moduleClass) ? d.removeSession(session) : d)
             .collect(Collectors.toList());

--- a/src/main/java/seedu/taassist/model/student/Student.java
+++ b/src/main/java/seedu/taassist/model/student/Student.java
@@ -97,6 +97,16 @@ public class Student implements Identity<Student> {
     }
 
     /**
+     * Returns a new student by removing the data for the given {@code session} in {@code moduleClass}
+     */
+    public Student removeSession(ModuleClass moduleClass, Session session) {
+        List<StudentModuleData> updatedModuleData = moduleDataList.asUnmodifiableObservableList().stream()
+            .map(d -> d.getModuleClass().isSame(moduleClass) ? d.removeSession(session) : d)
+            .collect(Collectors.toList());
+        return new Student(name, phone, email, address, updatedModuleData);
+    }
+
+    /**
      * Returns a new student by updating this student's grade for the
      * given {@code session} in {@code moduleClass}.
      */

--- a/src/test/java/seedu/taassist/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/DeleteCommandTest.java
@@ -34,7 +34,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getTaAssist(), new UserPrefs());
-        expectedModel.deleteStudent(studentToDelete);
+        expectedModel.removeStudent(studentToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -57,7 +57,7 @@ public class DeleteCommandTest {
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_STUDENT_SUCCESS, studentToDelete);
 
         Model expectedModel = new ModelManager(model.getTaAssist(), new UserPrefs());
-        expectedModel.deleteStudent(studentToDelete);
+        expectedModel.removeStudent(studentToDelete);
         showNoStudent(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/taassist/logic/commands/DeletecCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/DeletecCommandTest.java
@@ -222,7 +222,9 @@ public class DeletecCommandTest {
         @Override
         public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
             requireAllNonNull(moduleClasses);
-            return;
+            moduleClasses.forEach(moduleClass -> {
+                student = student.removeModuleClass(moduleClass);
+            });
         }
 
         @Override

--- a/src/test/java/seedu/taassist/logic/commands/DeletecCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/DeletecCommandTest.java
@@ -134,12 +134,12 @@ public class DeletecCommandTest {
     private static class ModelStubWithNoModuleClass extends ModelStub {
 
         @Override
-        public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
+        public void removeModuleClasses(Collection<ModuleClass> moduleClasses) {
             requireAllNonNull(moduleClasses);
         }
 
         @Override
-        public void deleteModuleClass(ModuleClass moduleClass) {
+        public void removeModuleClass(ModuleClass moduleClass) {
             requireNonNull(moduleClass);
         }
 
@@ -170,7 +170,7 @@ public class DeletecCommandTest {
         private Set<ModuleClass> moduleClasses = new HashSet<>(Arrays.asList(CS1101S, CS1231S));
 
         @Override
-        public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
+        public void removeModuleClasses(Collection<ModuleClass> moduleClasses) {
             requireAllNonNull(moduleClasses);
             this.moduleClasses = new HashSet<>();
         }
@@ -220,7 +220,7 @@ public class DeletecCommandTest {
         }
 
         @Override
-        public void deleteModuleClasses(Collection<ModuleClass> moduleClasses) {
+        public void removeModuleClasses(Collection<ModuleClass> moduleClasses) {
             requireAllNonNull(moduleClasses);
             moduleClasses.forEach(moduleClass -> {
                 student = student.removeModuleClass(moduleClass);

--- a/src/test/java/seedu/taassist/model/ModelStub.java
+++ b/src/test/java/seedu/taassist/model/ModelStub.java
@@ -122,7 +122,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void removeSession(ModuleClass moduleClass, Set<Session> sessions) {
+    public void removeSessions(ModuleClass moduleClass, Set<Session> sessions) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/taassist/model/ModelStub.java
+++ b/src/test/java/seedu/taassist/model/ModelStub.java
@@ -2,12 +2,14 @@ package seedu.taassist.model;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ObservableList;
 import seedu.taassist.commons.core.GuiSettings;
 import seedu.taassist.model.moduleclass.ModuleClass;
+import seedu.taassist.model.session.Session;
 import seedu.taassist.model.student.Student;
 
 /**
@@ -65,7 +67,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void deleteStudent(Student target) {
+    public void removeStudent(Student target) {
         throw new AssertionError("This method should not be called.");
     }
 
@@ -100,7 +102,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void deleteModuleClass(ModuleClass moduleClass) {
+    public void removeModuleClass(ModuleClass moduleClass) {
         throw new AssertionError("This method should not be called.");
     }
 
@@ -110,7 +112,17 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void deleteModuleClasses(Collection<ModuleClass> moduleClass) {
+    public void removeModuleClasses(Collection<ModuleClass> moduleClass) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeSession(ModuleClass moduleClass, Session session) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeSession(ModuleClass moduleClass, Set<Session> sessions) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/taassist/storage/JsonSerializableTaAssistTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonSerializableTaAssistTest.java
@@ -26,8 +26,6 @@ public class JsonSerializableTaAssistTest {
                 JsonSerializableTaAssist.class).get();
         TaAssist taAssistFromFile = dataFromFile.toModelType();
         TaAssist typicalStudentsTaAssist = TypicalStudents.getTypicalTaAssist();
-        System.out.println(JsonUtil.toJsonString(taAssistFromFile));
-        System.out.println(JsonUtil.toJsonString(typicalStudentsTaAssist));
         assertEquals(taAssistFromFile, typicalStudentsTaAssist);
     }
 


### PR DESCRIPTION
Resolves #149.

The immutable classes now provide an `add*`, `remove*` or `update*` method that returns a new instance by removing or updating a particular field.  This should greatly improve the abstraction. 

The `remove*` methods are soft, i.e. if the thing to be removed doesn't exist then same object is returned. 