### PR TITLE
Fix `export` command

### DIFF
--- a/src/main/java/seedu/taassist/model/session/Session.java
+++ b/src/main/java/seedu/taassist/model/session/Session.java
@@ -14,13 +14,14 @@ import seedu.taassist.model.uniquelist.Identity;
  * Guarantees: immutable; name is valid as declared in {@link #isValidSessionName(String)}
  */
 public class Session implements Identity<Session> {
-    public static final String MESSAGE_CONSTRAINTS = "Session names can take any values, but they should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Session names should contain only letters, digits, whitespace " +
+            "or underscores and should not be empty.";
 
     /*
      * The first character of the session must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "^[\\w\\s]+$";
 
     private final String sessionName;
     private final Date date;

--- a/src/main/java/seedu/taassist/model/session/Session.java
+++ b/src/main/java/seedu/taassist/model/session/Session.java
@@ -14,8 +14,8 @@ import seedu.taassist.model.uniquelist.Identity;
  * Guarantees: immutable; name is valid as declared in {@link #isValidSessionName(String)}
  */
 public class Session implements Identity<Session> {
-    public static final String MESSAGE_CONSTRAINTS = "Session names should contain only letters, digits, whitespace " +
-            "or underscores and should not be empty.";
+    public static final String MESSAGE_CONSTRAINTS = "Session names should contain only letters, digits, whitespace "
+            + "or underscores and should not be empty.";
 
     /*
      * The first character of the session must not be a whitespace,

--- a/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
@@ -39,7 +39,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_CLASS_CS1101S = "CS1101S";
     public static final String VALID_CLASS_CS1231S = "CS1231S";
-    public static final String VALID_SESSION_LAB1 = "LAB1";
+    public static final String VALID_SESSION_LAB1 = "LAB_1";
     public static final String VALID_SESSION_TUT3 = "Tutorial 3";
     public static final String VALID_DATE = "2022-01-01";
     public static final String VALID_GRADE_VALUE_12345 = "12.345";
@@ -55,7 +55,6 @@ public class CommandTestUtil {
     public static final String CLASS_DESC_CS1231S = " " + PREFIX_MODULE_CLASS + VALID_CLASS_CS1231S;
     public static final String CLASS_DESC_CS1101S = " " + PREFIX_MODULE_CLASS + VALID_CLASS_CS1101S;
     public static final String SESSION_DESC_LAB1 = " " + PREFIX_SESSION + VALID_SESSION_LAB1;
-    public static final String SESSION_DESC_TUT3 = " " + PREFIX_SESSION + VALID_SESSION_TUT3;
     public static final String DATE_DESC = " " + PREFIX_DATE + VALID_DATE;
     public static final String GRADE_VALUE_DESC_12345 = " " + PREFIX_GRADE + VALID_GRADE_VALUE_12345;
 
@@ -64,6 +63,8 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_CLASS_DESC = " " + PREFIX_MODULE_CLASS + "CS1101S*"; // '*' not allowed
     public static final String INVALID_INDEX = "-1"; // non-positive indices not allowed
+    public static final String INVALID_SESSION_COMMA_DESC = " " + PREFIX_SESSION + "foo,bar"; // ',' not allowed
+    public static final String INVALID_SESSION_EQUAL_DESC = " " + PREFIX_SESSION + "foo=bar"; // '=' not allowed
     public static final String INVALID_DATE = "2022/01/01";
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + INVALID_DATE;
     public static final String INVALID_GRADE_VALUE_DESC = " " + PREFIX_GRADE + "foo"; // strings not allowed

--- a/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/taassist/logic/commands/CommandTestUtil.java
@@ -63,8 +63,7 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_CLASS_DESC = " " + PREFIX_MODULE_CLASS + "CS1101S*"; // '*' not allowed
     public static final String INVALID_INDEX = "-1"; // non-positive indices not allowed
-    public static final String INVALID_SESSION_COMMA_DESC = " " + PREFIX_SESSION + "foo,bar"; // ',' not allowed
-    public static final String INVALID_SESSION_EQUAL_DESC = " " + PREFIX_SESSION + "foo=bar"; // '=' not allowed
+    public static final String INVALID_SESSION_NAME = " " + PREFIX_SESSION + "foo,bar"; // ',' not allowed
     public static final String INVALID_DATE = "2022/01/01";
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + INVALID_DATE;
     public static final String INVALID_GRADE_VALUE_DESC = " " + PREFIX_GRADE + "foo"; // strings not allowed

--- a/src/test/java/seedu/taassist/logic/commands/SessionCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/SessionCommandTest.java
@@ -11,4 +11,7 @@ public class SessionCommandTest {
     public void constructor_nullSession_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new SessionCommand(null));
     }
+
+
+
 }

--- a/src/test/java/seedu/taassist/logic/commands/SessionCommandTest.java
+++ b/src/test/java/seedu/taassist/logic/commands/SessionCommandTest.java
@@ -11,7 +11,4 @@ public class SessionCommandTest {
     public void constructor_nullSession_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new SessionCommand(null));
     }
-
-
-
 }

--- a/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/AddCommandParserTest.java
@@ -44,7 +44,6 @@ public class AddCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.COMMAND_WORD, AddCommand.MESSAGE_USAGE);
     private AddCommandParser parser = new AddCommandParser();
 
-
     @Test
     public void parse_allFieldsPresent_success() {
         Student expectedStudent = new StudentBuilder(BOB)

--- a/src/test/java/seedu/taassist/logic/parser/SessionCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/SessionCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.taassist.logic.parser;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.taassist.logic.commands.CommandTestUtil.DATE_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_COMMA_DESC;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_EQUAL_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.taassist.logic.commands.CommandTestUtil.SESSION_DESC_LAB1;
@@ -25,6 +27,7 @@ public class SessionCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, SessionCommand.COMMAND_WORD, SessionCommand.MESSAGE_USAGE);
     private SessionCommandParser parser = new SessionCommandParser();
 
+
     @Test
     public void parse_emptyUserInput_failure() {
         assertParseFailure(parser, PREAMBLE_WHITESPACE, MESSAGE_INVALID_FORMAT);
@@ -37,8 +40,10 @@ public class SessionCommandParserTest {
 
 
     @Test
-    public void parse_emptySessionName_failure() {
+    public void parse_invalidSessionName_failure() {
         assertParseFailure(parser, " " + PREFIX_SESSION + PREAMBLE_WHITESPACE, Session.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_SESSION_COMMA_DESC, Session.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_SESSION_EQUAL_DESC, Session.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/taassist/logic/parser/SessionCommandParserTest.java
+++ b/src/test/java/seedu/taassist/logic/parser/SessionCommandParserTest.java
@@ -3,8 +3,7 @@ package seedu.taassist.logic.parser;
 import static seedu.taassist.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.taassist.logic.commands.CommandTestUtil.DATE_DESC;
 import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_COMMA_DESC;
-import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_EQUAL_DESC;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_NAME;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.taassist.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.taassist.logic.commands.CommandTestUtil.SESSION_DESC_LAB1;
@@ -42,8 +41,7 @@ public class SessionCommandParserTest {
     @Test
     public void parse_invalidSessionName_failure() {
         assertParseFailure(parser, " " + PREFIX_SESSION + PREAMBLE_WHITESPACE, Session.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, INVALID_SESSION_COMMA_DESC, Session.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, INVALID_SESSION_EQUAL_DESC, Session.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_SESSION_NAME, Session.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/taassist/model/session/SessionTest.java
+++ b/src/test/java/seedu/taassist/model/session/SessionTest.java
@@ -2,6 +2,7 @@ package seedu.taassist.model.session;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_NAME;
 import static seedu.taassist.testutil.Assert.assertThrows;
 import static seedu.taassist.testutil.TypicalSessions.ASSIGNMENT_1;
 import static seedu.taassist.testutil.TypicalSessions.TUTORIAL_1;
@@ -14,10 +15,9 @@ public class SessionTest {
 
     @Test
     public void constructor_invalidSessionName_throwsIllegalArgumentException() {
-        String invalidSessionName = "";
         Date validDate = ASSIGNMENT_1.getDate();
-        assertThrows(IllegalArgumentException.class, () -> new Session(invalidSessionName));
-        assertThrows(IllegalArgumentException.class, () -> new Session(invalidSessionName, validDate));
+        assertThrows(IllegalArgumentException.class, () -> new Session(INVALID_SESSION_NAME));
+        assertThrows(IllegalArgumentException.class, () -> new Session(INVALID_SESSION_NAME, validDate));
     }
 
     @Test
@@ -75,12 +75,10 @@ public class SessionTest {
 
     @Test
     public void isValidSessionName() {
-        // special characters and whitespaces are allowed
-        assertTrue(Session.isValidSessionName("+/~@#$%^&* "));
-
-        // sessions names beginning with whitespaces are not allowed
-        assertFalse(Session.isValidSessionName(" Assignment 1"));
-
+        // underscores and whitespace are allowed
+        assertTrue(Session.isValidSessionName("_LAB 1_"));
+        // special characters are not allowed
+        assertFalse(Session.isValidSessionName("+/~@#$%^&* "));
         // empty session names are not allowed
         assertFalse(Session.isValidSessionName(""));
     }

--- a/src/test/java/seedu/taassist/storage/JsonAdaptedSessionTest.java
+++ b/src/test/java/seedu/taassist/storage/JsonAdaptedSessionTest.java
@@ -1,6 +1,8 @@
 package seedu.taassist.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.taassist.logic.commands.CommandTestUtil.INVALID_SESSION_NAME;
+import static seedu.taassist.logic.commands.CommandTestUtil.VALID_SESSION_LAB1;
 import static seedu.taassist.storage.JsonAdaptedSession.MISSING_DATE_MESSAGE_FORMAT;
 import static seedu.taassist.storage.JsonAdaptedSession.MISSING_NAME_MESSAGE_FORMAT;
 import static seedu.taassist.testutil.Assert.assertThrows;
@@ -14,9 +16,7 @@ import seedu.taassist.commons.exceptions.IllegalValueException;
 import seedu.taassist.model.session.Session;
 
 public class JsonAdaptedSessionTest {
-    private static final String INVALID_NAME = " ";
 
-    private static final String VALID_NAME = ASSIGNMENT_1.getSessionName();
     private static final LocalDate VALID_DATE = ASSIGNMENT_1.getDate().getValue();
 
     @Test
@@ -27,7 +27,7 @@ public class JsonAdaptedSessionTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedSession session = new JsonAdaptedSession(INVALID_NAME, VALID_DATE);
+        JsonAdaptedSession session = new JsonAdaptedSession(INVALID_SESSION_NAME, VALID_DATE);
         String expectedMessage = Session.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, session::toModelType);
     }
@@ -41,7 +41,7 @@ public class JsonAdaptedSessionTest {
 
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
-        JsonAdaptedSession session = new JsonAdaptedSession(VALID_NAME, null);
+        JsonAdaptedSession session = new JsonAdaptedSession(VALID_SESSION_LAB1, null);
         String expectedMessage = MISSING_DATE_MESSAGE_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, session::toModelType);
     }


### PR DESCRIPTION
Resolves #246 
* Enforce session names to contain only letters, digits, whitespace or underscores
  * Session names can begin with whitespaces. This was not allowed previously, please lmk if this change needs to be reverted
* The UG will be updated separately in #242 
 