### PR TITLE
Fix corrupt datafile getting backed up

### DIFF
--- a/docs/team/rezwanarefin01.md
+++ b/docs/team/rezwanarefin01.md
@@ -19,10 +19,9 @@ Given below are my contributions to the project.
         * The `grade` command to allow users to give grades to students for a session.
     * Implemented the `view` command to allow users to view session-wise grades of a student in a module.
     * Implemented feature to display current focused class (if any) in the GUI using bindings. 
-    * Added alert dialog to ask confirmation from users before starting with an empty data file if data load failed.
-        * Additionally, the data file is backed up everytime TA-Assist is opened.
     * Implemented collapsible student cards in the GUI to allow users to hide the student details.
-    * Added functionality to back up the data file each time TA-Assist is opened.
+    * Added alert dialog to ask confirmation from users before starting with an empty data file if data load failed.
+    * Added functionality to back up the data file everytime it is loaded successfully.
 
 * **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s1.github.io/tp-dashboard/?search=RezwanArefin01&breakdown=true).
 

--- a/src/main/java/seedu/taassist/MainApp.java
+++ b/src/main/java/seedu/taassist/MainApp.java
@@ -65,15 +65,6 @@ public class MainApp extends Application {
 
         initLogging(config);
 
-        try {
-            Path taAssistFilePath = userPrefs.getTaAssistFilePath();
-            if (FileUtil.isFileExists(taAssistFilePath)) {
-                storage.backupFile(taAssistFilePath);
-            }
-        } catch (IOException e) {
-            logger.warning("Failed to backup data file");
-        }
-
         model = initModelManager(storage, userPrefs);
         logic = new LogicManager(model, storage);
         ui = new UiManager(logic);
@@ -92,7 +83,9 @@ public class MainApp extends Application {
         ReadOnlyTaAssist initialData;
         try {
             taAssistOptional = storage.readTaAssist();
-            if (!taAssistOptional.isPresent()) {
+            if (taAssistOptional.isPresent()) {
+                backupTaAssist(userPrefs.getTaAssistFilePath());
+            } else {
                 logger.info("Data file not found. Will be starting with a sample TaAssist");
             }
             initialData = taAssistOptional.orElseGet(SampleDataUtil::getSampleTaAssist);
@@ -111,6 +104,21 @@ public class MainApp extends Application {
 
     private void initLogging(Config config) {
         LogsCenter.init(config);
+    }
+
+    /**
+     * Backs up the TA-Assist data file at the specified file path.
+     *
+     * @param taAssistFilePath The path to TA-Assist data file.
+     */
+    private void backupTaAssist(Path taAssistFilePath) {
+        try {
+            if (FileUtil.isFileExists(taAssistFilePath)) {
+                storage.backupFile(taAssistFilePath);
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to backup data file");
+        }
     }
 
     /**


### PR DESCRIPTION
Scenario: If an user edits the datafile and makes it corrupt, then in next run this corrupt file would be backed up, possibly overwriting a correct backup. 

Fix: Only correct data files should be backed up.